### PR TITLE
Optimization: move api manager to machiner.

### DIFF
--- a/adl.runtime/machinery/apimanager.ts
+++ b/adl.runtime/machinery/apimanager.ts
@@ -1,0 +1,111 @@
+import { IndentationText, QuoteKind, Project } from 'ts-morph';
+import { resolve, relative } from 'path';
+import { readFile, isDirectory, isFile} from '@azure-tools/async-io';
+
+import * as adltypes from '@azure-tools/adl.types';
+
+import * as machinerytypes from './machinery.types'
+import * as modeltypes from '../model/module'
+// this is not the cleanst way to do that, we can think of something better
+// the idea is to make each module as a stand alone as possible, only exporting module.ts
+// to external world
+import * as helpers from '../model/helpers';
+import { api_model } from '../model/apiModel';
+
+// api manager - aka store
+
+const manipulationSettings = {
+ indentationText: IndentationText.TwoSpaces,
+ insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: true,
+ quoteKind: QuoteKind.Single,
+};
+
+// json parser that allow comments
+function parseJsonc(text: string) {
+    return JSON.parse(text.replace(/\/\*[\s\S]*?\*\//gm, '')
+        .replace(/\s+\/\/.*/g, '')
+        .replace(/],(\s*?)\}/gm, ']$1}')
+        .replace(/},(\s*?)\}/gm, '}$1}'));
+}
+
+export class api_manager {
+    private _apiModels = new Map<string, modeltypes.ApiModel>();
+
+    get ApiModels(): Iterable<modeltypes.ApiModel> {
+        var infos = new Array<modeltypes.ApiModel>();
+
+        for(let [k,v] of this._apiModels)
+            infos.push(v);
+
+        return infos;
+    }
+
+    hasApiInfo(name: string): boolean{
+        return this._apiModels.has(name);
+    }
+
+    getApiInfo(name: string): modeltypes.ApiModel | undefined{
+        return this._apiModels.get(name);
+    }
+
+    constructor(private apimachinery: machinerytypes.ApiMachinery) {}
+
+
+    async addApi(options:modeltypes.apiProcessingOptions, apiName: string, projectDirectory: string): Promise<adltypes.errorList>{
+        const errors = new adltypes.errorList();
+
+        const apiModel = await this.loadApi(options, errors, apiName, projectDirectory);
+
+        // an error during load?
+        if(!apiModel) return errors;
+
+        this._apiModels.set(apiName, apiModel);
+        return errors;
+    }
+
+    async loadApi(options: modeltypes.apiProcessingOptions, errors:adltypes.errorList, apiName: string, projectDirectory: string): Promise<modeltypes.ApiModel | undefined> {
+        projectDirectory = resolve(projectDirectory);
+
+        if (!isDirectory(projectDirectory)){
+            const e = helpers.createLoadError(`Invalid Path ${projectDirectory} for ADL project`);
+            errors.push(e);
+            return undefined;
+        }
+
+        const configFile = resolve(projectDirectory, 'tsconfig.json');
+            if (!isFile(configFile)) {
+            const e = helpers.createLoadError(`No tsconfig at ${configFile}`);
+            errors.push(e);
+            return undefined;
+        }
+
+        const pkgFile = resolve(projectDirectory, 'package.json');
+        if(!isFile(pkgFile)) {
+            const e = helpers.createLoadError(`No packagejson at ${pkgFile}`);
+                errors.push(e);
+                return undefined;
+        }
+
+        const project = new Project({ tsConfigFilePath: configFile, manipulationSettings });
+        const loadedFiles = new Set<string>();
+
+        for (const each of project.getSourceFiles()) {
+            const sourceFile = each.getFilePath();
+            const content = await readFile(sourceFile);
+            const rPath = relative(projectDirectory, sourceFile);
+            loadedFiles.add(rPath);
+            project.createSourceFile(rPath, content);
+        }
+
+        const apiModel = new api_model(apiName, projectDirectory, project, loadedFiles, this.apimachinery);
+
+        apiModel.tsconfig = parseJsonc((await readFile(configFile)));
+        apiModel.package = parseJsonc((await readFile(pkgFile)));
+
+        const loaded = await apiModel.load(options, errors);
+        if(!loaded) return undefined;
+
+        return apiModel;
+    }
+}
+

--- a/adl.runtime/machinery/createMachinery.ts
+++ b/adl.runtime/machinery/createMachinery.ts
@@ -1,0 +1,9 @@
+
+import * as machinerytypes from './machinery.types'
+import * as modeltypes from '../model/model.types'
+
+import { api_machinery } from './machinery'
+// main entry point
+export function CreateMachinery(opts: modeltypes.apiProcessingOptions): machinerytypes.ApiMachinery{
+    return new api_machinery(opts);
+}

--- a/adl.runtime/machinery/machinery.types.ts
+++ b/adl.runtime/machinery/machinery.types.ts
@@ -24,11 +24,6 @@ export class machineryLoadableRuntime{
     // conversion constraints implementation
     readonly conversionImplementations: Map<string, ConversionConstraintImpl> = new Map<string, ConversionConstraintImpl>();
 
-    // custom shared versioners, typically used when there is a shared envelop across multiple spec
-    readonly versioners: Map<string, any> = new Map<string/*type name*/, any /* containing module */ >();
-
-    // custom shared versioners, typically used when there is a shared envelop across multiple spec
-    readonly normalizers: Map<string, any> = new Map<string/*type name*/, any /* containing module */ >();
     constructor(private _name: string){}
 }
 
@@ -342,12 +337,4 @@ export interface ApiMachinery{
 
     // creates a runtime instance for store
     createRuntime(store: ApiManager): ApiRuntime;
-
-    // normalizers and versioners
-    hasVersioner(name:string):boolean;
-    hasNormalizer(name:string):boolean;
-    activateVersioner(name:string): any;
-    activateNormalizer(name:string): any;
 }
-
-

--- a/adl.runtime/machinery/module.ts
+++ b/adl.runtime/machinery/module.ts
@@ -1,4 +1,4 @@
 
 export * from './machinery.types'
-export * from './machinery'
+export * from './createMachinery'
 

--- a/adl.runtime/machinery/runtime.ts
+++ b/adl.runtime/machinery/runtime.ts
@@ -332,15 +332,8 @@ export class apiRuntime implements machinerytypes.ApiRuntime{
         // run the imperative versioner
         if(versionedTypeModel.VersionerName == adltypes.AUTO_VERSIONER_NAME) return;
 
-        let imperative_versioner: adltypes.Versioner<adltypes.Normalized, adltypes.Versioned>;
-        if(this.machinery.hasVersioner(versionedTypeModel.VersionerName)){
-            this.opts.logger.info(`runtime versioner:${versionedTypeModel.VersionerName} normalize ${apiModel.Name}/${versionName}/${versionedTypeModel.Name} => ${normalizedApiTypeModel.Name}`);
-            imperative_versioner =  this.machinery.activateVersioner(versionedTypeModel.VersionerName) as adltypes.Versioner<adltypes.Normalized, adltypes.Versioned>;
-        }else{
-            this.opts.logger.info(`spec versioner:${versionedTypeModel.VersionerName} normalize ${apiModel.Name}/${versionName}/${versionedTypeModel.Name} => ${normalizedApiTypeModel.Name}`);
-            imperative_versioner  = apiModel.createSpecInstance(versionedTypeModel.VersionerName) as adltypes.Versioner<adltypes.Normalized, adltypes.Versioned>;
-        }
-
+        this.opts.logger.info(`spec versioner:${versionedTypeModel.VersionerName} normalize ${apiModel.Name}/${versionName}/${versionedTypeModel.Name} => ${normalizedApiTypeModel.Name}`);
+        const imperative_versioner  = apiModel.createSpecInstance(versionedTypeModel.VersionerName) as adltypes.Versioner<adltypes.Normalized, adltypes.Versioned>;
         // run it == TODO: metric collection here
         imperative_versioner.Normalize(versioned as adltypes.Versioned, normalized as adltypes.Versioned, errors);
     }
@@ -612,16 +605,9 @@ export class apiRuntime implements machinerytypes.ApiRuntime{
         // auto  already ran
         if(versionedTypeModel.VersionerName == adltypes.AUTO_VERSIONER_NAME) return;
 
-        this.opts.logger.verbose(`custom versioner:${versionedTypeModel.VersionerName} is versioning ${normalizedApiTypeModel.Name} => ${apiModel.Name}/${versionName}/${versionedTypeModel.Name}`);
+       this.opts.logger.verbose(`spec versioner:${versionedTypeModel.VersionerName} version ${normalizedApiTypeModel.Name} => ${apiModel.Name}/${versionName}/${versionedTypeModel.Name}`);
+        const imperative_versioner= apiModel.createSpecInstance(versionedTypeModel.VersionerName) as adltypes.Versioner<adltypes.Normalized, adltypes.Versioned>;
 
-        let imperative_versioner: adltypes.Versioner<adltypes.Normalized, adltypes.Versioned>;
-        if(this.machinery.hasVersioner(versionedTypeModel.VersionerName)){
-            this.opts.logger.verbose(`runtime versioner:${versionedTypeModel.VersionerName} version ${normalizedApiTypeModel.Name} => ${apiModel.Name}/${versionName}/${versionedTypeModel.Name}`);
-            imperative_versioner = this.machinery.activateVersioner(versionedTypeModel.VersionerName) as  adltypes.Versioner<adltypes.Normalized, adltypes.Versioned>;
-        }else{
-            this.opts.logger.verbose(`runtime versioner:${versionedTypeModel.VersionerName} version ${normalizedApiTypeModel.Name} => ${apiModel.Name}/${versionName}/${versionedTypeModel.Name}`);
-            imperative_versioner= apiModel.createSpecInstance(versionedTypeModel.VersionerName) as adltypes.Versioner<adltypes.Normalized, adltypes.Versioned>;
-        }
         // run it == TODO: metric collection here
         imperative_versioner.Convert(normalized as adltypes.Versioned, versioned as adltypes.Versioned, errors);
 
@@ -878,14 +864,9 @@ export class apiRuntime implements machinerytypes.ApiRuntime{
         if(normalizedApiTypeModel.NormalizerName == adltypes.AUTO_NORMALIZER_NAME)
             return;
 
-        let imperative_normalizer: adltypes.Normalizer<adltypes.Normalized>;
-        if(this.machinery.hasNormalizer(normalizedApiTypeModel.NormalizerName)){
-            this.opts.logger.verbose(`runtime normalizer:${normalizedApiTypeModel.NormalizerName} is defaulting ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
-            imperative_normalizer = this.machinery.activateNormalizer(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
-        }else{
-            this.opts.logger.verbose(`custom normalizer:${normalizedApiTypeModel.NormalizerName} is defaulting ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
-            imperative_normalizer = apiModel.createSpecInstance(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
-        }
+        this.opts.logger.verbose(`spec normalizer:${normalizedApiTypeModel.NormalizerName} is defaulting ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
+        const imperative_normalizer = apiModel.createSpecInstance(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
+
         // run it == TODO: metric collection here
         imperative_normalizer.Default(normalizedTyped, errors);
     }
@@ -1103,18 +1084,11 @@ export class apiRuntime implements machinerytypes.ApiRuntime{
         const existingNormalizedTyped = adltypes.isComplex(existingPayload) ? existingPayload : JSON.parse(existingPayload);
         const rootField = adltypes.getRootFieldDesc();
 
+        if(normalizedApiTypeModel.NormalizerName== adltypes.AUTO_NORMALIZER_NAME) return;
 
-
-        let imperative_normalizer: adltypes.Normalizer<adltypes.Normalized>;
-        if(this.machinery.hasNormalizer(normalizedApiTypeModel.NormalizerName)){
-            this.opts.logger.verbose(`runtime normalizer:${normalizedApiTypeModel.NormalizerName} is validating ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
-            imperative_normalizer = this.machinery.activateNormalizer(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
-        }else{
-            this.opts.logger.verbose(`custom normalizer:${normalizedApiTypeModel.NormalizerName} is validating ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
-            imperative_normalizer = apiModel.createSpecInstance(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
-        }
-
-        imperative_normalizer.Validate(undefined, normalizedTyped, errors);
+        this.opts.logger.verbose(`spec normalizer:${normalizedApiTypeModel.NormalizerName} is validating ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
+        const imperative_normalizer = apiModel.createSpecInstance(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
+        imperative_normalizer.Validate(existingPayload, normalizedTyped, errors);
     }
 
     validate_normalized_oncreate(payload: string | any, apiName: string, normalizedApiTypeName: string, errors: adltypes.errorList):void{
@@ -1127,21 +1101,10 @@ export class apiRuntime implements machinerytypes.ApiRuntime{
         const normalizedTyped = adltypes.isComplex(payload) ? payload : JSON.parse(payload);
         const rootField = adltypes.getRootFieldDesc();
 
-        if(normalizedApiTypeModel.NormalizerName != adltypes.AUTO_NORMALIZER_NAME){
-            this.opts.logger.verbose(`custom normalizer:${normalizedApiTypeModel.NormalizerName} is validating ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
-            const imperative_normalizer = apiModel.createSpecInstance(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
-            imperative_normalizer.Validate(undefined, normalizedTyped, errors);
-        }
+        if(normalizedApiTypeModel.NormalizerName== adltypes.AUTO_NORMALIZER_NAME) return;
 
-        let imperative_normalizer: adltypes.Normalizer<adltypes.Normalized>;
-        if(this.machinery.hasNormalizer(normalizedApiTypeModel.NormalizerName)){
-            this.opts.logger.verbose(`runtime normalizer:${normalizedApiTypeModel.NormalizerName} is validating ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
-            imperative_normalizer = this.machinery.activateNormalizer(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
-        }else{
-            this.opts.logger.verbose(`custom normalizer:${normalizedApiTypeModel.NormalizerName} is validating ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
-            imperative_normalizer = apiModel.createSpecInstance(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
-        }
-
+        this.opts.logger.verbose(`custom normalizer:${normalizedApiTypeModel.NormalizerName} is validating ${apiModel.Name}/${normalizedApiTypeModel.Name}`);
+        const imperative_normalizer = apiModel.createSpecInstance(normalizedApiTypeModel.NormalizerName) as adltypes.Normalizer<adltypes.Normalized>;
         imperative_normalizer.Validate(undefined, normalizedTyped, errors);
     }
 
@@ -1166,10 +1129,27 @@ export class apiRuntime implements machinerytypes.ApiRuntime{
 
         // api won't load if the reference by name does not exist.
         const normalizedTypeModel = apiModel.getNormalizedApiType(versionedTypeModel.NormalizedApiTypeName) as modeltypes.NormalizedApiTypeModel;
-
         const versionedTyped =  adltypes.isComplex(payload) ? payload : JSON.parse(payload);
-
         const rootField = adltypes.getRootFieldDesc();
+
+        /* TODO: @khenidak optimize
+         * we currently walk the object graph too many time
+         * walk for missing keys
+         * walk for extra keys
+         * walk for auto conversion // we have to separete auto from running constraints. because we are not sure of cross reference dependability
+         * walk for running conversion constraints
+         * walk for running defaulting constraints
+         * walk for running validation constraints
+         * we can compress the above into few walks by the following
+         * Alpha: Missing and extra keys as part of the auto conversion (-2 walks)
+         * beta: surface hasPropertiesWith*Constraints() (where *=>conversion, defaulting, validation) on complex objects, and walk *only* when this value is true.
+         * gama: (long term)
+         * we currently separate the walks because we want spec author to assume that *autoAction* is done. e.g if i am defaulting then i can saftely
+         * assume that all the auto conversion and auto defaulting has ran. eg: i can saftely read other parts of the object graph. if we can limit this
+         * supportability. then we can compress the 3 walks into one. but it will take away a big -important - feature for perf.
+         * the decision on gama must depend on our performance goals.
+         */
+
         // missing keys
         const missingKeys = new Map<string, adltypes.fieldDesc>();
         this.buildMissingKeys(versionedTyped, versionedTypeModel, rootField, missingKeys);

--- a/adl.runtime/model/apiModel.ts
+++ b/adl.runtime/model/apiModel.ts
@@ -2,6 +2,8 @@ import { Project, SourceFile, TypeReferenceNode } from 'ts-morph';
 
 import * as adltypes from '@azure-tools/adl.types';
 import * as modeltypes from './model.types';
+import * as machinerytypes from '../machinery/machinery.types'
+
 import * as helpers from './helpers'
 
 import { api_version } from './apiVersion';
@@ -36,7 +38,7 @@ export class api_model implements modeltypes.ApiModel{
         return infos;
     }
 
-    constructor(private name:string, private rootPath: string, private project:Project, private loadedFiles: Set<string>){}
+    constructor(private name:string, private rootPath: string, private project:Project, private loadedFiles: Set<string>, private apimachinery: machinerytypes.ApiMachinery){}
 
     getVersion(name: string): modeltypes.ApiVersionModel | undefined{
         return this._apiVersionModels.get(name);
@@ -56,16 +58,16 @@ export class api_model implements modeltypes.ApiModel{
 
     hasVersioner(name: string): boolean{
         if(this._imported == undefined) throw new Error("attempt was made to interact wth loadable spec before it finishes loading");
-            return this._imported[name] != undefined;
+            return this.apimachinery.hasVersioner(name) ||  this._imported[name] != undefined;
     }
 
     hasNormalizer(name: string): boolean{
         if(this._imported == undefined) throw new Error("attempt was made to interact wth loadable spec before it finishes loading");
-            return this._imported[name] != undefined;
+            return this.apimachinery.hasNormalizer(name) || this._imported[name] != undefined;
     }
 
     createSpecInstance(name:string): any | undefined{
-            if(!this.hasVersioner(name)) return undefined;
+        if(!this.hasVersioner(name)) return undefined;
             return new this._imported[name]();
     }
 
@@ -195,8 +197,8 @@ export class api_model implements modeltypes.ApiModel{
         }
         // same goes for imperative normalizer
         for(const normalizedType of this.NormalizedTypes){
-                // auto is always there
-                if(normalizedType.NormalizerName == adltypes.AUTO_NORMALIZER_NAME)
+            // auto is always there
+            if(normalizedType.NormalizerName == adltypes.AUTO_NORMALIZER_NAME)
                 continue;
 
             if(!this.hasNormalizer(normalizedType.NormalizerName)){

--- a/adl.runtime/model/apiModel.ts
+++ b/adl.runtime/model/apiModel.ts
@@ -58,16 +58,16 @@ export class api_model implements modeltypes.ApiModel{
 
     hasVersioner(name: string): boolean{
         if(this._imported == undefined) throw new Error("attempt was made to interact wth loadable spec before it finishes loading");
-            return this.apimachinery.hasVersioner(name) ||  this._imported[name] != undefined;
+            return this._imported[name] != undefined;
     }
 
     hasNormalizer(name: string): boolean{
         if(this._imported == undefined) throw new Error("attempt was made to interact wth loadable spec before it finishes loading");
-            return this.apimachinery.hasNormalizer(name) || this._imported[name] != undefined;
+            return  this._imported[name] != undefined;
     }
 
     createSpecInstance(name:string): any | undefined{
-        if(!this.hasVersioner(name)) return undefined;
+        if(this._imported == undefined) throw new Error("attempt was made to interact wth loadable spec before it finishes loading");
             return new this._imported[name]();
     }
 

--- a/adl.types/core/adl.ts
+++ b/adl.types/core/adl.ts
@@ -28,7 +28,8 @@ export interface Versioned{
 }
 
 export interface Normalizer<N extends Normalized> {
- Default(obj: N, errors: errorList) : void;
+    // imperative defaulting logic, called upon defaulting an api type
+    Default(obj: N, errors: errorList) : void;
     // Validate is called with
     // (undefined, new, errorlist) in case of object creation
     // (old, new, update) in case of object update
@@ -48,6 +49,14 @@ export interface Versioner<N extends Normalized,V extends Versioned>{
     Convert(normalized: N, versioned: V,errors: errorList): void;
 }
 
+
+// type guards
+export function isNormalizer(o:any): o is Normalizer<Normalized>{
+    return o != undefined && (o as Normalizer<Normalized>).Default != undefined && (o as Normalizer<Normalized>).Validate != undefined;
+}
+export function isVersioner(o:any): o is Versioner<Normalized, Versioned>{
+    return o != undefined && (o as Versioner<Normalized, Versioned>).Normalize != undefined && (o as Versioner<Normalized, Versioned>).Convert != undefined;
+}
 
 /* error type is the only type defined at the global leve
  * because it is used in conversion and validation

--- a/arm.adl/src/runtime-creator.ts
+++ b/arm.adl/src/runtime-creator.ts
@@ -13,14 +13,6 @@ export class RuntimeCreator implements adlruntime.RuntimeCreator{
         const runtimeDef =  new adlruntime.machineryLoadableRuntime(ARM_RUNTIME_NAME);
         // add swagger generator
         runtimeDef.generators.set("arm.swagger", new armSwaggerGen.armSwaggerGenerator());
-
-
-        // add arm custom versioner
-        runtimeDef.versioners.set("ArmVersioner" /*type name of versioner */, armtypes /*containing module */);
-
-        // add arm custom normalizer
-        runtimeDef.normalizers.set("ArmNormalizer" /*type name of versioner */, armtypes /*containing module */);
-
         return runtimeDef;
     }
 }

--- a/arm.adl/src/runtime-creator.ts
+++ b/arm.adl/src/runtime-creator.ts
@@ -1,7 +1,8 @@
 import * as adlruntime from '@azure-tools/adl.runtime'
-
+import * as adltypes from '@azure-tools/adl.types'
 // import swagger gen here
 import * as armSwaggerGen from './swagger-generator/module'
+import * as armtypes from './types'
 // we load runtime into adl runtime. to supply adl runtime withour generators
 // normalizers etc..
 export const ARM_RUNTIME_NAME= "arm";
@@ -12,6 +13,13 @@ export class RuntimeCreator implements adlruntime.RuntimeCreator{
         const runtimeDef =  new adlruntime.machineryLoadableRuntime(ARM_RUNTIME_NAME);
         // add swagger generator
         runtimeDef.generators.set("arm.swagger", new armSwaggerGen.armSwaggerGenerator());
+
+
+        // add arm custom versioner
+        runtimeDef.versioners.set("ArmVersioner" /*type name of versioner */, armtypes /*containing module */);
+
+        // add arm custom normalizer
+        runtimeDef.normalizers.set("ArmNormalizer" /*type name of versioner */, armtypes /*containing module */);
 
         return runtimeDef;
     }

--- a/arm.adl/src/types.ts
+++ b/arm.adl/src/types.ts
@@ -37,6 +37,7 @@ export class ArmNormalizer<props> implements adltypes.Normalizer<ArmNormalizedRe
     Validate (old: ArmNormalizedResource<props> | undefined, newObject: ArmNormalizedResource<props>, errors: adltypes.errorList) : void{
         //no-op
     }
+    constructor(){}
 }
 
 // Arm envelop for versioned resource.
@@ -66,4 +67,5 @@ export class ArmVersioner<normalizedProps extends adltypes.Normalized,
     Convert(normalized: ArmNormalizedResource<normalizedProps> , versioned: ArmVersionedResource<versionedProps>, errors: adltypes.errorList): void{
         //no-op
     }
+    constructor(){}
 }

--- a/cli/src/appContext.ts
+++ b/cli/src/appContext.ts
@@ -2,7 +2,7 @@ import * as adlruntime from '@azure-tools/adl.runtime'
 
 export class appContext {
     store: adlruntime.ApiManager; // actual store
-    machinery: adlruntime.apiMachinery; // api design time. e.g. constraints system
+    machinery: adlruntime.ApiMachinery; // api design time. e.g. constraints system
     machineryRuntime: adlruntime.ApiRuntime; // api runtime implem entation e.g. normalize()/convert()
     opts: adlruntime.apiProcessingOptions;
 }

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -67,41 +67,13 @@ export class adlCliParser extends CommandLineParser {
         // wire up log level
         ctx.opts.logger.logLevel = adlruntime.apiProcessingLogLevel[this._log_level.value as string];
 
-        ctx.store = new adlruntime.ApiManager();
-        ctx.machinery = new adlruntime.apiMachinery(ctx.opts);
+        // create the machinery using our opts
+        const machinery = adlruntime.CreateMachinery(ctx.opts);
+        // keep it in context
+        ctx.machinery = machinery
+        // use it to create an api manager (store)
+        ctx.store = machinery.createApiManager();
 
-        const loadApis = this._pre_load_api.values
-        // typicall there would be a configuration file for cairo
-        // where we set the preloaded apis in it. TODO
-        if(loadApis.length == 0){
-            //TODO: for demo purposes, we are loading a sample
-            // in a typical scneario, user will connect to rpaas
-            // endpoint to load the data.
-            ctx.opts.logger.info(`auto loading sample_rp apis`);
-            await ctx.store.addApi(ctx.opts,
-                                "sample_rp",
-                                "/home/khenidak/go/src/github.com/khenidak/adl/sample_rp" );
-        }else{
-            // if there are values provided in command line then load from there
-            for(const api of loadApis){
-                const message = `expected loadable apis to be in form of 'name=<name>+path=<path>'`;
-
-                // no error handling here
-                const defParts = api.split("+");
-                let apiName:string = "";
-                let apiPath:string = "";
-                for(const defPart of defParts)
-                {
-                    const varParts = defPart.split("=");
-                    if(varParts.length != 2 || (varParts[0] !== "name" && varParts[0] !=="path")) throw new Error(message);
-                    if(varParts[0] == "name")  apiName = varParts[1];
-                    if(varParts[0] == "path") apiPath = varParts[1];
-                }
-                ctx.opts.logger.info(`preloading apis ${apiName} from ${apiPath}`);
-                await ctx.store.addApi(ctx.opts, apiName, apiPath);
-                ctx.opts.logger.verbose(`loaded apis ${apiName} from ${apiPath}`);
-            }
-        }
 
         // loadable runtimes
         const runtimes = this._pre_load_runtime.values;
@@ -136,8 +108,41 @@ export class adlCliParser extends CommandLineParser {
         }
 
 
-        this.ctx.machineryRuntime = this.ctx.machinery.createRuntime(this.ctx.store);
+        const loadApis = this._pre_load_api.values
+        // typicall there would be a configuration file for cairo
+        // where we set the preloaded apis in it. TODO
+        if(loadApis.length == 0){
+            //TODO: for demo purposes, we are loading a sample
+            // in a typical scneario, user will connect to rpaas
+            // endpoint to load the data.
+            ctx.opts.logger.info(`auto loading sample_rp apis`);
+            await ctx.store.addApi(ctx.opts,
+                                "sample_rp",
+                                "/home/khenidak/go/src/github.com/khenidak/adl/sample_rp" );
+        }else{
+            // if there are values provided in command line then load from there
+            for(const api of loadApis){
+                const message = `expected loadable apis to be in form of 'name=<name>+path=<path>'`;
 
+                // no error handling here
+                const defParts = api.split("+");
+                let apiName:string = "";
+                let apiPath:string = "";
+                for(const defPart of defParts)
+                {
+                    const varParts = defPart.split("=");
+                    if(varParts.length != 2 || (varParts[0] !== "name" && varParts[0] !=="path")) throw new Error(message);
+                    if(varParts[0] == "name")  apiName = varParts[1];
+                    if(varParts[0] == "path") apiPath = varParts[1];
+                }
+                ctx.opts.logger.info(`preloading apis ${apiName} from ${apiPath}`);
+                await ctx.store.addApi(ctx.opts, apiName, apiPath);
+                ctx.opts.logger.verbose(`loaded apis ${apiName} from ${apiPath}`);
+            }
+        }
+
+        // a runtime wrapping our store into context
+        this.ctx.machineryRuntime = machinery.createRuntime(this.ctx.store);
         return super.onExecute();
   }
 }


### PR DESCRIPTION
This is a minor optimization to how the code is structured. it goes as the following:

1. apimanager moved to machinery.
2. api machinery now is the creator for runtime and api managers.

the most obvious effect of this is, how the runtime startup routine now looks like like. Here is a typical approach (check cli root command)
```
opts = new adlruntime.apiProcessingOptions(); // create the opts
// optionally set log level and other information
// create the machinery using our opts
const machinery = adlruntime.CreateMachinery(ctx.opts);
//use it to create an api manager (store)
store = machinery.createApiManager();
// load runtimes 
machinery.loadRuntime(...)
// load apis
store.addApi(...)
```
