### PR TITLE
nullable types and runtime support

### DIFF
--- a/adl.runtime/model/model.types.ts
+++ b/adl.runtime/model/model.types.ts
@@ -99,6 +99,7 @@ export interface PropertyDataType{
     hasAliasDataTypeConstraint(): boolean;
     hasEnumConstraint(): boolean;
     hasConstraint(name:string):boolean;
+    hasNullableConstraint(): boolean;
 }
 // scalar data type
 export interface PropertyScalarDataType extends PropertyDataType{
@@ -117,6 +118,7 @@ export interface PropertyArrayDataType extends PropertyDataType{
     readonly ElementConstraints:Array<ConstraintModel>;
     hasElementAliasDataTypeConstraint(): boolean;
     hasElementEnumConstraint(): boolean;
+    isElementNullable():boolean;
 }
 export interface PropertySimpleArrayDataType extends PropertyArrayDataType{
     readonly ElementDataTypeName: string;
@@ -137,6 +139,7 @@ export interface PropertyMapDataType extends PropertyDataType{
     readonly KeyEnumValues: any[];
     hasKeyAliasDataTypeConstraint(): boolean;
     hasKeyEnumConstraint(): boolean;
+    readonly isValueNullable: boolean;
 }
 
 // simple map
@@ -236,7 +239,9 @@ export interface ApiTypePropertyModel extends loadableObject{
     readonly DataTypeKind: PropertyDataTypeKind;
     // property is optional
     readonly isOptional: boolean;
-    // returns the complex data type for property if available;
+    // data type for this property can be null
+    readonly isNullable: boolean;
+
     // don't run auto conversion on type
     readonly isManaullyConverted: boolean;
     // returns true if the type is aliased via DataType<Name>;

--- a/adl.types/constraints/behavior_property.ts
+++ b/adl.types/constraints/behavior_property.ts
@@ -5,3 +5,9 @@ export interface Removed extends PropertyBehaviorConstraint{}
 
 // Runtime: don't run auto conversion on this property
 export interface NoAutoConversion extends PropertyBehaviorConstraint{}
+
+/** nullable types. by default adl assumes that all
+ * values are non-nullable unless this interface is
+ * used to declare that the value. can be nullable
+ */
+export interface Nullable extends PropertyBehaviorConstraint{}

--- a/adl.types/core/constants.ts
+++ b/adl.types/core/constants.ts
@@ -13,11 +13,10 @@ export const INTERFACE_NAME_APITYPECONSTRAINT: string = "ApiTypeConstraint";
 
 export const CONSTRAINT_NAME_REMOVED: string = "Removed";
 export const CONSTRAINT_NAME_NOAUTOCONVERSION: string = "NoAutoConversion";
+export const CONSTRAINT_NAME_NULLABLE = "Nullable";
 
 export const AUTO_VERSIONER_NAME: string = "AutoVersioner";
 export const AUTO_NORMALIZER_NAME: string = "AutoNormalizer";
-
-
 
 export const NORMALIZED_TYPE_DEF_SUPER_NAME: string = "CustomNormalizedApiType";
 export const VERSIONED_TYPE_DEF_SUPER_NAME:string = "CustomApiType";
@@ -26,4 +25,5 @@ export const CONSTRAINT_NAME_MODULENAME:string = "ModuleName";
 export const CONSTRAINT_NAME_APIVERSIONNAME = "ApiVersion";
 
 export const ADL_MAP_TYPENAME = "AdlMap";
+
 

--- a/adl.types/datatypes/non_primitives.ts
+++ b/adl.types/datatypes/non_primitives.ts
@@ -16,8 +16,6 @@ type Kind<V> = V & TypeOf<V>;
 /** Declares the property is a polymorphic discriminator */
 type Discriminator<V> = V;
 
-// TODO: Create a dictionary that has
-// validation for keys and values
 /** an dictionary of key(string)/value pairs */
 export interface AdlMap<K,V> {}
 

--- a/sample_rp/20200909/vm.ts
+++ b/sample_rp/20200909/vm.ts
@@ -25,7 +25,7 @@ export interface VirtualMachineProps{
     *  @prop_tag1 because we are using jsdoc, we can use tags. those are also exposed to whoever consumes the model
     *  @prop_tag2 also, consumer can ensure documentation conformation for example mandatory tags
     */
-    vmId : string;
+    vmId : string & adltypes.Nullable;
 
     hardwareProfile: HWProfile;
 

--- a/sample_rp/normalized/vm.ts
+++ b/sample_rp/normalized/vm.ts
@@ -10,7 +10,7 @@ interface VirtualMachineProps{
     *  @prop_tag1 because we are using jsdoc, we can use tags. those are also exposed to whoever consumes the model
     *  @prop_tag2 also, consumer can ensure documentation conformation for example mandatory tags
     */
-    vmId : string & adltypes.ReadOnly & adltypes.MaxLength<5> & adltypes.MinLength<2>;
+    vmId : string & adltypes.ReadOnly & adltypes.MaxLength<5> & adltypes.MinLength<2> & adltypes.Nullable;
 
     hardwareProfile: HWProfile;
     storageProfile: ImageReference;


### PR DESCRIPTION
This pr adds nullability support to base type system and runtime. 

*by default all adl types are non nullable unless set to nullable*

**How to use?**
```typescript
type interface Person{
Addresses:Address[] & Nullable; // the array itself is nullable
}
```
or
```typescript
type interface Person{
Addresses:Address & Nullable[]; // the array element is nullable
}
```
same applies on maps. as an example 

```typescript
interface Person{
Children: AdlMap<string, number & Nullable>;// value can be null
}
```

but the following is not allowed


```typescript
interface Person{
Children: AdlMap<string & Nullable, number & Nullable>;// key can't be null
}
```

**note**
Validation is triggered for non null values. Consider this
```typescript
interface Person{
FirstName: string & Nullable & MaxLength<5>; // translates to. it is a string that can be null, but if it is not, then maximum length allowed is 5.
}
```

so
```person.FirstName == null``` => ok
```person.FirstName == "abcdefghijk"``` => not ok, max length constraint is not satisfied

**defaulting and nullability**

given

```typescript
interface Person{
FirstName: string & Nullable & DefaultValue<IamKal>
}
```
a value that looks like 
`person.FirstName == null` => will be defaulted it to  `person.FirstName == "IamKal"`

