### PR TITLE
fix boolean defaulting

### DIFF
--- a/adl.runtime/machinery/constraints/defaulting.ts
+++ b/adl.runtime/machinery/constraints/defaulting.ts
@@ -18,7 +18,7 @@ export class DefaultValueImpl implements machinerytypes.DefaultingConstraintImpl
         }
 
         // set default value
-        if(leveledTyped[context.propertyName] == undefined){
+        if(leveledTyped.hasOwnProperty(context.propertyName) || leveledTyped[context.propertyName] == null){
             if(p.DataTypeName == "string") {
                 leveledTyped[context.propertyName] = String(context.ConstraintArgs[0]);
                 return;
@@ -30,7 +30,7 @@ export class DefaultValueImpl implements machinerytypes.DefaultingConstraintImpl
             }
 
             if(p.DataTypeName == "boolean"){
-                leveledTyped[context.propertyName] = Boolean(context.ConstraintArgs[0]);
+                leveledTyped[context.propertyName] = JSON.parse(context.ConstraintArgs[0]); // *sigh*
                 return;
             }
         }
@@ -44,7 +44,7 @@ export class DefaultValueImpl implements machinerytypes.DefaultingConstraintImpl
             leveledTyped[context.propertyName] = Number(context.ConstraintArgs[0] as number);
             return;
         }
-        // boolean has to be set if the property is not undefined.
+        // boolean can't be set if the property is not null or exist.
     }
 }
 

--- a/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
+++ b/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
@@ -7,8 +7,7 @@
         "coreCount": 100,
         "dataDisks": [
             {
-                "diskId": "diskid-here",
-		"isSSD": true
+                "diskId": "diskid-here"
             }
         ],
         "hardwareProfile": {

--- a/sample_rp/20200909/vm.ts
+++ b/sample_rp/20200909/vm.ts
@@ -62,8 +62,9 @@ export interface ImageReference{
 
 export interface DataDisk {
     diskId: armtypes.ArmResourceId;
-    isSSD: boolean;
+    isSSD?: boolean;
 }
+
 interface NetworkCard{
     networkCardId: armtypes.ArmResourceId;
 }

--- a/sample_rp/normalized/vm.ts
+++ b/sample_rp/normalized/vm.ts
@@ -56,14 +56,13 @@ interface DataDisk {
     diskId: armtypes.ArmResourceId; // note: custom type
     diskSize?: number & adltypes.DefaultValue<160>;
     //defaulted boolean
-    isUltra?: boolean & adltypes.DefaultValue<true>;
+    isUltra?: boolean & adltypes.DefaultValue<false>;
     // undefauled boolean
-    isSSD: boolean;
+    isSSD?: boolean;
 }
 
 interface HWProfile {
-    virtualMachineSize: string &
-                        adltypes.DefaultValue<'ds_v2'>;
+    virtualMachineSize: string & adltypes.DefaultValue<'ds_v2'>;
 }
 
 interface NetworkCard{


### PR DESCRIPTION
Fixes a problem where `DefaultValue<.>` constraint incorrectly sets `DefaultValue<false>`as true value (instead of false value).

