### PR TITLE
must match (regexp) constraint

### DIFF
--- a/adl.runtime/machinery/machinery.ts
+++ b/adl.runtime/machinery/machinery.ts
@@ -85,6 +85,9 @@ export class api_machinery implements machinerytypes.ApiMachinery{
         const val5i = new constraints.MinLengthImpl();
         adlcore.validationImplementations.set("MinLength", val5i);
 
+        const val6i = new constraints.MustMatchImpl();
+        adlcore.validationImplementations.set("MustMatch", val6i);
+
         const conv1i = new constraints.MapToImpl();
         adlcore.conversionImplementations.set("MapTo", conv1i);
 

--- a/adl.types/constraints/validation_property.ts
+++ b/adl.types/constraints/validation_property.ts
@@ -29,7 +29,7 @@ export interface Range<L extends number, H extends number> extends ValidationCon
  *
  * @param T - the regular expression
 */
-export interface MustMatch<T extends string> extends PropertyConstraint {}
+export interface MustMatch<doubleEscapedRE extends string> extends ValidationConstraint{}
 
 
 /** a number value that is a multiple of a given number */

--- a/arm.adl/src/types.ts
+++ b/arm.adl/src/types.ts
@@ -1,15 +1,18 @@
 import *  as adltypes from '@azure-tools/adl.types'
-/* the below allows arm developer to define resources without having to
- * worry about arm tracking information
- */
+// TODO: we should define constraints that allows use to express resource of specific provider and type
+// example: NetworkCard = string & adltypes.DataType<'networkCard'> & ArmResourceId<'microsoft.network', 'card'>
+// the definition of ArmResourceId will look like this ArmResourceId<provider, type> extends MustMatch<...>
+
 export type SubscriptionId = string;
 export type Location = string;
 export type ResourceGroup = string;
 
 // Arm common data types.
-export type ArmResourceId = string & adltypes.MustMatch<'TODO: ARM RESOURCE ID REG EXP'>
-export type ResourceType = string & adltypes.MustMatch<'TODO: ARM RESOURCE TYPE REG EXP'>
-export type ArmResourceName = string & adltypes.MustMatch<'TODO: ARM RESOURCE TYPE REG EXP'>;
+
+export type ArmResourceId = string & adltypes.DataType<'ArmResourceId'> &
+                            adltypes.MustMatch<'\\/subscriptions\\/[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}\\/resourcegroups\\/[-\\w\\._\\(\\)]+\\/[-\\w\\._\\(\\)]+\\/*.'>
+export type ResourceType = string & adltypes.MustMatch<'^[-\\w\\._\\(\\)]+'>
+export type ArmResourceName = string & adltypes.MustMatch<'^[-\\w\\._\\(\\)]+'>;
 
 
 // Arm envelop for normalized resource

--- a/docs_ex/sample-rp-sample-data/vm-normalized.json
+++ b/docs_ex/sample-rp-sample-data/vm-normalized.json
@@ -1,22 +1,22 @@
 {
     "etag": "",
-    "id": "",
+    "id": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.compute/virtualmachine/vm1",
     "location": "",
     "name": "",
     "properties": {
         "coreCount": 100,
         "dataDisks": [
             {
-                "diskId": "diskid-here",
+                "diskId": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.disks/disks/disk1",
 		"isSSD": true
             }
         ],
         "hardwareProfile": {
-            "vmSize": "StandardDS_v3"
+            "virtualMachineSize": "StandardDS_v3"
         },
         "networkCards": {
             "third": {
-                "networkCardId": "network-card-id"
+                "networkCardId": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.network/network-card/card1"
             }
         },
         "storageProfile": {
@@ -28,7 +28,7 @@
         "v1Prop": 9,
         "vmId": "string-here"
     },
-    "resourceGroup": "my resource group",
+    "resourceGroup": "myresourcegroup",
     "tags": {
         "key1": "val1",
         "key2": "val2"

--- a/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
+++ b/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
@@ -1,13 +1,13 @@
 {
     "etag": "",
-    "id": "",
+    "id": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.compute/virtualmachine/vm1",
     "location": "",
-    "name": "",
+    "name": "myvm",
     "properties": {
         "coreCount": 100,
         "dataDisks": [
             {
-                "diskId": "diskid-here"
+                "diskId": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.disks/disks/disk1"
             }
         ],
         "hardwareProfile": {
@@ -15,7 +15,7 @@
         },
         "networkCards": {
             "third": {
-                "networkCardId": "network-card-id"
+                "networkCardId": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.network/network-card/card1"
             }
         },
         "storageProfile": {
@@ -27,7 +27,7 @@
         "v1Prop": 9,
         "vmId": "str"
     },
-    "resourceGroup": "my resource group",
+    "resourceGroup": "myresourcegroup",
     "tags": {
         "key1": "val1",
         "key2": "val2"

--- a/sample_rp/normalized/vm.ts
+++ b/sample_rp/normalized/vm.ts
@@ -49,7 +49,7 @@ interface ImageReference{
     sku: string;
 
     version: string &
-             adltypes.MustMatch<'some-arbitrary-regex'>;
+             adltypes.MustMatch<'^[-\\w\\._\\(\\)]+'>;
 }
 
 interface DataDisk {


### PR DESCRIPTION
Implements must MustMatch<RegExp> constraint. Due to the way typescript process string (when they are a generic type constraint), **user must double escape the regexp**.

Use it:
```typescript
interface Person{
FirstName: string & MustMatch<'DOUBLE-ESCAPED-REG-EXP'>;
}
```

You can also define a custom type
```typescript
type email = string & MustMatch<'email-double-escaped-reg-exp'>;
```
then you can use it  as 
```typescript
interface person{
Email: email; // using defined type with its own constraint
}
```
