### PR TITLE
Implementation of MultipleOf

### DIFF
--- a/adl.runtime/machinery/constraints/validation.ts
+++ b/adl.runtime/machinery/constraints/validation.ts
@@ -167,3 +167,26 @@ export class RangeImpl implements machinerytypes.ValidationConstraintImpl{
     }
 }
 
+export class MultipleOfImpl implements machinerytypes.ValidationConstraintImpl{
+    Run(
+        context: machinerytypes.ConstraintExecContext,
+        rootTyped: any,
+        leveledTyped: any,
+        existingRootTyped: any | undefined,
+        existingLeveledTyped: any | undefined,
+        rootApiTypeModel: modeltypes.ApiTypeModel,
+        leveledApiTypeModel: modeltypes.ApiTypeModel,
+        isMapKey: boolean): boolean{
+            const propVal = leveledTyped[context.propertyName];
+            const factor = context.ConstraintArgs[0] as number;
+            
+            if (propVal == undefined) return true;
+
+            if ((propVal as number) % factor != 0) {
+                context.errors.push(machinerytypes.createValidationError(`value ${propVal} is not multiple of ${factor}.`, context.fieldPath));
+                return false;
+            }
+
+            return true;
+    }
+}

--- a/adl.runtime/machinery/machinery.ts
+++ b/adl.runtime/machinery/machinery.ts
@@ -88,6 +88,9 @@ export class api_machinery implements machinerytypes.ApiMachinery{
         const val6i = new constraints.MustMatchImpl();
         adlcore.validationImplementations.set("MustMatch", val6i);
 
+        const val7i = new constraints.MultipleOfImpl();
+        adlcore.validationImplementations.set("MultipleOf", val7i);
+
         const conv1i = new constraints.MapToImpl();
         adlcore.conversionImplementations.set("MapTo", conv1i);
 

--- a/adl.types/constraints/validation_property.ts
+++ b/adl.types/constraints/validation_property.ts
@@ -33,7 +33,7 @@ export interface MustMatch<doubleEscapedRE extends string> extends ValidationCon
 
 
 /** a number value that is a multiple of a given number */
-export interface MultipleOf<N extends number> extends PropertyConstraint {}
+export interface MultipleOf<N extends number> extends ValidationConstraint {}
 
 
 /** the maximum number of items in an Array */

--- a/docs_ex/sample-rp-sample-data/vm-normalized.json
+++ b/docs_ex/sample-rp-sample-data/vm-normalized.json
@@ -26,6 +26,7 @@
             "version": "version field value"
         },
         "v1Prop": 9,
+        "v3Prop": 15,
         "vmId": "string-here"
     },
     "resourceGroup": "myresourcegroup",

--- a/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
+++ b/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
@@ -25,6 +25,7 @@
             "version": "version field value"
         },
         "v1Prop": 9,
+        "v3Prop": 15,
         "vmId": "str"
     },
     "resourceGroup": "myresourcegroup",

--- a/sample_rp/20200909/vm.ts
+++ b/sample_rp/20200909/vm.ts
@@ -35,6 +35,10 @@ export interface VirtualMachineProps{
 
     v1Prop: number;
 
+    v3Prop?: adltypes.int64 &
+             adltypes.MultipleOf<3> &
+             adltypes.MultipleOf<5>;
+
     coreCount: number & adltypes.MapTo<'totalCores'>;
 
     /**

--- a/sample_rp/normalized/vm.ts
+++ b/sample_rp/normalized/vm.ts
@@ -26,6 +26,10 @@ interface VirtualMachineProps{
     v2Prop?: string &
              adltypes.DefaultValue<'defaulted  declartively'>;
 
+  v3Prop?: adltypes.int64 &
+           adltypes.MultipleOf<3> &
+           adltypes.MultipleOf<5>;
+
     /**
     *  this is another property documentation, i can here describe the property for user facing doc. I can also
     *  provide tags. the farmework can help in asserting that certain tags are exposed. make sure that docs


### PR DESCRIPTION
Implementation of `MultipleOf` constraint.

example `MultipleOf<5>` ensures that a number value is a multiple of 5. 