### PR TITLE
MustMatch<Regex> : Support to configure case sensitivity 

### DIFF
--- a/adl.runtime/machinery/constraints/validation.ts
+++ b/adl.runtime/machinery/constraints/validation.ts
@@ -16,8 +16,9 @@ export class MustMatchImpl implements machinerytypes.ValidationConstraintImpl{
        const propVal = leveledTyped[context.propertyName];
        let regExp = context.ConstraintArgs[0];
        regExp = regExp.replace(/\\\\/g, '\\');
-       const re = new RegExp(regExp);
-       context.opts.logger.verbose(`constraint: MustMatch prop:${context.propertyName} with value (${propVal}) applying compiled regExp:${re.source}`);
+       let ignoreCase = JSON.parse(context.ConstraintArgs[1]);
+       const re = ignoreCase ? new RegExp(regExp, 'i') : new RegExp(regExp);
+       context.opts.logger.verbose(`constraint: MustMatch prop:${context.propertyName} with value (${propVal}) applying compiled regExp:${re.source} with ignore case set to ${ignoreCase}`);
 
        if(!re.test(propVal)){
          const propModel = leveledApiTypeModel.getProperty(context.propertyName) as modeltypes.ApiTypePropertyModel;

--- a/adl.types/constraints/validation_property.ts
+++ b/adl.types/constraints/validation_property.ts
@@ -29,7 +29,7 @@ export interface Range<L extends number, H extends number> extends ValidationCon
  *
  * @param T - the regular expression
 */
-export interface MustMatch<doubleEscapedRE extends string> extends ValidationConstraint{}
+export interface MustMatch<doubleEscapedRE extends string, ignoreCase extends boolean> extends ValidationConstraint{}
 
 
 /** a number value that is a multiple of a given number */

--- a/adl.types/datatypes/non_primitives.ts
+++ b/adl.types/datatypes/non_primitives.ts
@@ -43,7 +43,7 @@ export type unixtime = number  & DataType<"unixtime">;
 /** a universally unique ID */
 export type uuid = string &
                    DataType<"uuid"> &
-                   adlconstraints.MustMatch<'^([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}$'>;
+                   adlconstraints.MustMatch<'^([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}$', /*ignoreCase*/ true>;
 
 /** A Uniform Resource Identifier (URI) is a string of characters that unambiguously identifies a particular resource.
  *
@@ -51,7 +51,7 @@ export type uuid = string &
 */
 export type uri = string &
                   DataType<"uri"> &
-                  adlconstraints.MustMatch<'^[A-Za-z][A-Za-z0-9+\-.]*:.*^'>;
+                  adlconstraints.MustMatch<'^[A-Za-z][A-Za-z0-9+\-.]*:.*^', /*ignoreCase*/ true>;
 
 /** a single character  */
 export type char = string &

--- a/arm.adl/src/types.ts
+++ b/arm.adl/src/types.ts
@@ -10,9 +10,9 @@ export type ResourceGroup = string;
 // Arm common data types.
 
 export type ArmResourceId = string & adltypes.DataType<'ArmResourceId'> &
-                            adltypes.MustMatch<'\\/subscriptions\\/[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}\\/resourcegroups\\/[-\\w\\._\\(\\)]+\\/[-\\w\\._\\(\\)]+\\/*.'>
-export type ResourceType = string & adltypes.MustMatch<'^[-\\w\\._\\(\\)]+'>
-export type ArmResourceName = string & adltypes.MustMatch<'^[-\\w\\._\\(\\)]+'>;
+                            adltypes.MustMatch<'\\/subscriptions\\/[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}\\/resourcegroups\\/[-\\w\\._\\(\\)]+\\/[-\\w\\._\\(\\)]+\\/*.', /*ignoreCase*/ true>
+export type ResourceType = string & adltypes.MustMatch<'^[-\\w\\._\\(\\)]+', /*ignoreCase*/ true>
+export type ArmResourceName = string & adltypes.MustMatch<'^[-\\w\\._\\(\\)]+', /*ignoreCase*/ true>;
 
 
 // Arm envelop for normalized resource

--- a/docs_ex/core-concepts.md
+++ b/docs_ex/core-concepts.md
@@ -37,7 +37,7 @@ An apis spec author can use validation constraints to define how property value 
 ```
 person{
 	firstName: string & MinLength<4> & MaxLength<24>; /* min and max length of name property*/
-	email: string & MustMatch<'^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$'> & Immutable; /* email property must match a regular expression and is immutable*/
+	email: string & MustMatch<'^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$',  /*ignoreCase*/ true> & Immutable; /* email property must match a regular expression and is immutable*/
 	addresses: address[]; & MaxEntries<32> /*max element count of address array is 32 */
 	children: person[];
 	motherMaidenName: string;
@@ -63,7 +63,7 @@ adl supports composability and extensibility in multiple ways. Below are some ex
 A spec author can define custom data types that can be reused within api types
 ```typescripe
 // typically defined
-type zipcode = number & MustMatch<'(^\d{5}$)|(^\d{9}$)|(^\d{5}-\d{4}$)'>;
+type zipcode = number & MustMatch<'(^\d{5}$)|(^\d{9}$)|(^\d{5}-\d{4}$)',  /*ignoreCase*/ true>;
 
 // it can be then used as the following
 interface Address{

--- a/docs_ex/sample-rp-sample-data/resource_two_2020-09-09.json
+++ b/docs_ex/sample-rp-sample-data/resource_two_2020-09-09.json
@@ -1,12 +1,13 @@
 {
-    "etag": "",
-    "id": "",
-    "location": "",
-    "name": "",
-    "properties": {
-        "prop1": 199,
-        "prop2": "prop2"
-    },
-    "resourceGroup": "",
-    "type": ""
+  "etag": "",
+  "id": "/SUBSCRIPTIONS/d3f20976-17ab-4f77-a99b-a64552938998/RESOURCEGROUPS/cairo/providers/microsoft.Foo/resource_two/vm1",
+  "name": "resourcetwo-test",
+  "location": "",
+  "properties": {
+    "prop1": 199,
+    "prop2": "prop2",
+    "prop3": "PROP"
+  },
+  "resourceGroup": "",
+  "type": "resource_two"
 }

--- a/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
+++ b/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
@@ -1,36 +1,36 @@
 {
-    "etag": "",
-    "id": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.compute/virtualmachine/vm1",
-    "location": "",
-    "name": "myvm",
-    "properties": {
-        "coreCount": 100,
-        "dataDisks": [
-            {
-                "diskId": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.disks/disks/disk1"
-            }
-        ],
-        "hardwareProfile": {
-            "vmSize": "StandardDS_v3"
-        },
-        "networkCards": {
-            "third": {
-                "networkCardId": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.network/network-card/card1"
-            }
-        },
-        "storageProfile": {
-            "offer": "offer field value",
-            "publisher": "publisher field value",
-            "sku": "sku field value",
-            "version": "version field value"
-        },
-        "v1Prop": 9,
-        "vmId": "str"
-    },
-    "resourceGroup": "myresourcegroup",
-    "tags": {
-        "key1": "val1",
-        "key2": "val2"
-    },
-    "type": "virtualmachine"
+	"etag": "",
+	"id": "/SUBSCRIPTIONS/d3f20976-17ab-4f77-a99b-a64552938998/RESOURCEGROUPS/cairo/providers/microsoft.compute/virtualmachine/vm1",
+	"location": "",
+	"name": "myvm",
+	"properties": {
+		"coreCount": 100,
+		"dataDisks": [
+			{
+				"diskId": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.disks/disks/disk1"
+			}
+		],
+		"hardwareProfile": {
+			"vmSize": "StandardDS_v3"
+		},
+		"networkCards": {
+			"third": {
+				"networkCardId": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.network/network-card/card1"
+			}
+		},
+		"storageProfile": {
+			"offer": "offer field value",
+			"publisher": "publisher field value",
+			"sku": "sku field value",
+			"version": "version field value"
+		},
+		"v1Prop": 9,
+		"vmId": "str"
+	},
+	"resourceGroup": "myresourcegroup",
+	"tags": {
+		"key1": "val1",
+		"key2": "val2"
+	},
+	"type": "virtualmachine"
 }

--- a/sample_rp/20200909/resource_two.ts
+++ b/sample_rp/20200909/resource_two.ts
@@ -14,6 +14,7 @@ import * as normalized from '../normalized/module'
 class ResourceTwo{
     prop1: number;
     prop2: string;
+    prop3: string;
 }
 
 // because we work with arm wrapped resources, our versioner need to work with them as well

--- a/sample_rp/normalized/resource_two.ts
+++ b/sample_rp/normalized/resource_two.ts
@@ -13,7 +13,10 @@ export class ResourceTwoProps{
                  adltypes.Immutable;
 
     prop2: string &
-                 adltypes.MustMatch<'^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$'>;
+                 adltypes.MustMatch<'^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$', /*ignoreCase*/ true>;
+
+    prop3: string &
+                adltypes.MustMatch<'^[A-Z0-9_\\-\\.]+$', /*ignoreCase*/ false>;
 }
 
 // because we work with wrapped resouce our normalizer needs to work with wrapped resources as well

--- a/sample_rp/normalized/vm.ts
+++ b/sample_rp/normalized/vm.ts
@@ -49,7 +49,7 @@ interface ImageReference{
     sku: string;
 
     version: string &
-             adltypes.MustMatch<'^[-\\w\\._\\(\\)]+'>;
+             adltypes.MustMatch<'^[-\\w\\._\\(\\)]+', /*ignoreCase*/ true>;
 }
 
 interface DataDisk {


### PR DESCRIPTION
Added support to configure case sensitivity for MustMatch<> constraint.
Updated resourceId, uri etc.. to do case-insensitive matching.
Added prop3 to resource-two to validate case-sensitive comparion (all upper only)