### PR TITLE
reduce object graph walks by 1/3

### DIFF
--- a/adl.runtime/model/apiType.ts
+++ b/adl.runtime/model/apiType.ts
@@ -47,7 +47,7 @@ export class api_type implements modeltypes.ApiTypeModel{
 
     get Name():string{return this._name;}
 
-    get Properties(): Iterable<modeltypes.ApiTypePropertyModel> {
+    get Properties(): Array<modeltypes.ApiTypePropertyModel> {
         var infos = new Array<modeltypes.ApiTypePropertyModel>();
 
         for(let [k,v] of this._properties)

--- a/adl.runtime/model/model.types.ts
+++ b/adl.runtime/model/model.types.ts
@@ -48,7 +48,7 @@ export interface ApiTypeModel extends loadableObject{
     readonly Name: string;
     readonly Docs: ApiJsDoc | undefined;
 
-    readonly Properties: Iterable<ApiTypePropertyModel>;
+    readonly Properties: Array<ApiTypePropertyModel>;
     readonly Constraints:Array<ConstraintModel>;
 
     getProperty(propertyName: string): ApiTypePropertyModel | undefined;


### PR DESCRIPTION
during conversion we walk 6 times across the input object graph to do conversion, validation and other logic. This PR reduces them by 1/3 by eliminating the need to walk to get `extra` and `missing` keys. This PR is first of series of PRs focus on perf.