### PR TITLE
Feature: MoveTo constraint

### DIFF
--- a/adl.runtime/machinery/constraints/conversion/module.ts
+++ b/adl.runtime/machinery/constraints/conversion/module.ts
@@ -1,1 +1,2 @@
 export * from './renameto'
+export * from './moveto'

--- a/adl.runtime/machinery/constraints/conversion/moveto.ts
+++ b/adl.runtime/machinery/constraints/conversion/moveto.ts
@@ -1,0 +1,121 @@
+import * as adltypes from '@azure-tools/adl.types'
+import * as machinerytypes from '../../machinery.types'
+import * as modeltypes from '../../../model/module'
+
+
+export class MoveToImpl implements machinerytypes.ConversionConstraintImpl{
+	private ensureObjectGraph(context: machinerytypes.ConstraintExecContext,
+                              jsonPath: string,
+                              rootModel: modeltypes.ApiTypeModel,
+                              rootPayload:any,
+							  buildIt: boolean): {outModel: modeltypes.ApiTypeModel; outPayload: any;} | undefined{
+
+        let stepModel = rootModel;
+        let stepPayload = rootPayload;
+
+        const parts = jsonPath.split(".");
+
+        const first = parts[0];
+        if(first == `$`){ // special handling to the $ at the begining of the path
+            const reminders = parts.slice(1); // cut
+            const newPath = reminders.join(".");
+            return this.ensureObjectGraph(context, newPath, stepModel, stepPayload, buildIt);
+        }
+
+        // define the property if it does not exist
+        if(!stepPayload.hasOwnProperty(first)){
+			if(!buildIt) return undefined;
+
+            stepPayload[first] = {}; // we always assume it is nested objects
+        }
+        const reminders = parts.slice(1); // cut
+        const newPath = reminders.join(".");
+        const isLast = (reminders.length == 1);
+
+        if(!isLast){
+            // work on the rest
+            stepPayload = stepPayload[first];
+            stepModel = (stepModel.getProperty(first) as modeltypes.ApiTypePropertyModel).getComplexDataTypeOrThrow();
+            return this.ensureObjectGraph(context, newPath, stepModel, stepPayload, buildIt);
+        }
+        return {
+            outModel: (stepModel.getProperty(first) as modeltypes.ApiTypePropertyModel).getComplexDataTypeOrThrow(),
+            outPayload: stepPayload[first],
+        }
+    }
+
+ 	private getPropertyNameFromPath(jpath: string): string{
+        const parts = jpath.split(".");
+        return parts[parts.length - 1];
+    }
+
+    ConvertToNormalized(
+        context: machinerytypes.ConstraintExecContext,
+        rootVersioned: any,
+        leveledVersioned: any,
+        rootNormalized: any,
+        leveledNormalized: any,
+        rootVersionedModel:modeltypes.ApiTypeModel,
+        leveledVersionedModel:modeltypes.ApiTypeModel,
+        rootNormalizedModel: modeltypes.ApiTypeModel,
+        leveledNormalizedModel: modeltypes.ApiTypeModel,
+        versionName: string):{targetModel: modeltypes.ApiTypeModel,targetProperty:modeltypes.ApiTypePropertyModel, target:any} | undefined {
+
+     	// for now we assume the path is valid, because once conformance framework is complete
+        // each constraint will be validated
+        const toPath = context.ConstraintArgs[0] as string;
+        const toProp = this.getPropertyNameFromPath(toPath);
+        const fromProp = context.propertyName;
+
+        context.opts.logger.verbose(`MoveTo(v=>n): toPath:${toPath} sourceProperty:${fromProp} targetProp:${toProp}`)
+        const ensured  = this.ensureObjectGraph(context, toPath, rootNormalizedModel, rootNormalized, true /*build target graph */);
+		if(!ensured) return undefined; // this wouldn't happen here.
+
+        let actualleveledNormalizedModel:modeltypes.ApiTypeModel = ensured.outModel;
+        let actualLevelNormalized: any = ensured.outPayload;
+
+		// once we validate constraint itself this won't be needed
+        if(!actualleveledNormalizedModel) return undefined;
+        if(!actualLevelNormalized) return undefined;
+		let actualProperty = actualleveledNormalizedModel.getProperty(fromProp) as modeltypes.ApiTypePropertyModel;
+
+		 return {targetModel: actualleveledNormalizedModel, targetProperty: actualProperty, target: actualLevelNormalized};
+    }
+
+    ConvertToVersioned(
+        context: machinerytypes.ConstraintExecContext,
+        rootVersioned: any,
+        leveledVersioned: any,
+        rootNormalized: any,
+        leveledNormalized: any,
+        rootVersionedModel:modeltypes.ApiTypeModel,
+        leveledVersionedModel:modeltypes.ApiTypeModel,
+        rootNormalizedModel: modeltypes.ApiTypeModel,
+        leveledNormalizedModel: modeltypes.ApiTypeModel,
+       	versionName: string) : {targetModel: modeltypes.ApiTypeModel,targetProperty:modeltypes.ApiTypePropertyModel,target:any} | undefined {
+
+		// for now we assume the path is valid, because once conformance framework is complete
+        // each constraint will be validated
+        const toPath = context.ConstraintArgs[0] as string;
+        const toProp = this.getPropertyNameFromPath(toPath);
+        const fromProp = context.propertyName;
+
+        context.opts.logger.verbose(`MoveTo(n=>v): toPath:${toPath} sourceProperty:${fromProp} targetProp:${toProp}`)
+        const ensured  = this.ensureObjectGraph(context, toPath, rootNormalizedModel, rootNormalized, false);
+		if(!ensured){
+ 			context.opts.logger.verbose(`MoveTo(n=>v): there is no source at this path ${toPath}`)
+			 return undefined;
+		}
+
+        let actualleveledNormalizedModel:modeltypes.ApiTypeModel = ensured.outModel;
+        let actualLevelNormalized: any = ensured.outPayload;
+
+		// once we validate constraint itself this won't be needed
+        if(!actualleveledNormalizedModel) return undefined;
+        if(!actualLevelNormalized) return undefined;
+		let actualProperty = actualleveledNormalizedModel.getProperty(fromProp) as modeltypes.ApiTypePropertyModel;
+
+		 return {targetModel: actualleveledNormalizedModel, targetProperty: actualProperty, target: actualLevelNormalized};
+
+    }
+}

--- a/adl.runtime/machinery/machinery.ts
+++ b/adl.runtime/machinery/machinery.ts
@@ -94,6 +94,9 @@ export class api_machinery implements machinerytypes.ApiMachinery{
         const conv1i = new constraints.RenameToImpl();
         adlcore.conversionImplementations.set("RenameTo", conv1i);
 
+        const conv2i = new constraints.MoveToImpl();
+        adlcore.conversionImplementations.set("MoveTo", conv2i);
+
         return adlcore;
     }
 

--- a/adl.types/constraints/conversion_property.ts
+++ b/adl.types/constraints/conversion_property.ts
@@ -5,5 +5,9 @@ import { ConversionConstraint } from './types'
 // versioned  => normalized
 // normalized => versioned
 
-// maps the property from one location to another
+// tells auto conversion logic that the property has a different name on target
 export interface RenameTo<sourceNameOrJPath extends string> extends ConversionConstraint{}
+
+// tells auto conversion logic that the property has moved to a different part of the output object graph
+export interface MoveTo<targetJsonPath extends string> extends ConversionConstraint{}
+

--- a/docs_ex/sample-rp-sample-data/vm-normalized.json
+++ b/docs_ex/sample-rp-sample-data/vm-normalized.json
@@ -8,7 +8,7 @@
         "dataDisks": [
             {
                 "diskId": "/subscriptions/d3f20976-17ab-4f77-a99b-a64552938998/resourcegroups/cairo/providers/microsoft.disks/disks/disk1",
-		"isSSD": true
+                "isSSD": true
             }
         ],
         "hardwareProfile": {
@@ -24,6 +24,13 @@
             "publisher": "publisher field value",
             "sku": "sku field value",
             "version": "version field value"
+        },
+        "userProfile": {
+            "passwordProfile": {
+                "password": "abc$123",
+                "publicKey": "my-ssh-publick-key"
+            },
+            "username": "vmuser"
         },
         "v1Prop": 9,
         "v3Prop": 15,

--- a/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
+++ b/docs_ex/sample-rp-sample-data/vm_2020-09-09.json
@@ -3,12 +3,6 @@
     "id": "/SUBSCRIPTIONS/d3f20976-17ab-4f77-a99b-a64552938998/RESOURCEGROUPS/cairo/providers/microsoft.compute/virtualmachine/vm1",
     "location": "",
     "name": "myvm",
-    "type": "virtualmachine",
-    "resourceGroup": "myresourcegroup",
-    "tags": {
-        "key1": "val1",
-        "key2": "val2"
-    },
     "properties": {
         "coreCount": 100,
         "dataDisks": [
@@ -33,7 +27,16 @@
             "sku": "sku field value",
             "version": "version field value"
         },
+        "username": "vmuser",
         "v1Prop": 9,
-        "vmId": "str"
-    }
+        "vmId": "str",
+        "password": "abc$123",
+        "publicKey": "my-ssh-publick-key"
+    },
+    "resourceGroup": "myresourcegroup",
+    "tags": {
+        "key1": "val1",
+        "key2": "val2"
+    },
+    "type": "virtualmachine"
 }

--- a/sample_rp/20200909/vm.ts
+++ b/sample_rp/20200909/vm.ts
@@ -54,6 +54,10 @@ export interface VirtualMachineProps{
     networkCards?: adltypes.AdlMap<string, NetworkCard>;
 
     specials: somethingSpecial[];
+
+ 	username: string & adltypes.MoveTo<'$.properties.userProfile.username'>;
+    password: string & adltypes.MoveTo<'$.properties.userProfile.passwordProfile.password'>;
+    publicKey: string & adltypes.MoveTo<'$.properties.userProfile.passwordProfile.publicKey'>;
 }
 
 export interface HWProfile {

--- a/sample_rp/normalized/vm.ts
+++ b/sample_rp/normalized/vm.ts
@@ -44,6 +44,8 @@ interface VirtualMachineProps{
     networkCards?: adltypes.AdlMap<string, NetworkCard>;
 
     specials: somethingSpecial[];
+
+	userProfile?: UserProfile;
 }
 
 interface ImageReference{
@@ -76,6 +78,16 @@ interface HWProfile {
 interface NetworkCard{
     networkCardId: armtypes.ArmResourceId;
     networkName?: string & adltypes.DefaultValue<'my_net_name'>;
+}
+
+interface PasswordProfile{
+    password?: string;
+    publicKey?: string;
+}
+
+interface UserProfile{
+    username?: string;
+    passwordProfile?: PasswordProfile;
 }
 // we have defined this resource, but we want arm core properties, so we envelop it
 export type VirtualMachineNormalized = armtypes.ArmNormalizedResource<VirtualMachineProps>;


### PR DESCRIPTION
allows the spec author to use declarative approach to convert between two structurally different object graph. For Example:

source
```typescript
interface myFancyApiType{
 userProfile?: UserProfile;
}
interface PasswordProfile{
    password?: string;
    publicKey?: string;
}
interface UserProfile{
    username?: string;
    passwordProfile?: PasswordProfile;
}
```
target
```typescript
interface myOtherFancyApiType{
    username: string & adltypes.MoveTo<'$.properties.userProfile.username'>;
    password: string & adltypes.MoveTo<'$.properties.userProfile.passwordProfile.password'>;
    publicKey: string & adltypes.MoveTo<'$.properties.userProfile.passwordProfile.publicKey'>;
}
```

The `MoveTo` uses json path to read from and to target. User can use it to move a property, an array, a map or an entire sub object graph. The entire conversion constraint process is hierarchical

**important**
when moving objects (with renamed props) the user is advised to `assign MoveTo at the root of the object that move` then use `RenameTo` for properties that has been renamed. The reason we want that is we build the target tree in the process of moving and that requires another walk from the root of the target object check code in `MoveTo` constraint for more information.