### PR TITLE
add adl apis

### DIFF
--- a/adl.runtime/apis/adl.apis/adl-v1/error.ts
+++ b/adl.runtime/apis/adl.apis/adl-v1/error.ts
@@ -1,0 +1,24 @@
+import * as adltypes from "@azure-tools/adl.types";
+import * as apisnormalized from '../normalized/module'
+
+// versioned view of error
+export interface error{
+    errorType : string & adltypes.NoAutoConversion;
+    errorMessage: string & adltypes.NoAutoConversion;
+    fieldPath?: string & adltypes.NoAutoConversion;
+}
+
+
+export class errorVersioner implements adltypes.Versioner<apisnormalized._error, error>{
+    Normalize(versioned: error, normalized: apisnormalized._error, errors: adltypes.errorList) : void{
+        throw new Error("normalizing an error is not supported");// Reason being, errors are not saved or processed like a regular api type
+    }
+    // creates a versioned view of the error
+    Convert(normalized: apisnormalized._error, versioned: error ,errors: adltypes.errorList): void{
+        versioned.errorType = normalized.errorType;
+        versioned.errorMessage = normalized.errorMessage;
+        if(normalized.field != undefined){
+            versioned.fieldPath = normalized.field.path;
+        }
+    }
+}

--- a/adl.runtime/apis/adl.apis/adl-v1/errorlist.ts
+++ b/adl.runtime/apis/adl.apis/adl-v1/errorlist.ts
@@ -1,0 +1,24 @@
+import * as adltypes from "@azure-tools/adl.types";
+import * as apisnormalized from '../normalized/module'
+
+import * as e from './error'
+// versioned view of errorList
+export interface errorList {
+}
+
+//!!! DON NOT USE UNTIL ADL SUPPORTS ROOT ARRAY TYPES !!!
+export class errorListVersioner implements adltypes.Versioner<apisnormalized._errorList, errorList>{
+    Normalize(versioned: errorList, normalized: apisnormalized._errorList, errors: adltypes.errorList) : void{
+        throw new Error("normalizing an errorList is not supported");// Reason being, errors are not saved or processed like a regular api type
+    }
+    // creates a versioned view of the error
+    Convert(normalized: apisnormalized._errorList, versioned: errorList, errors: adltypes.errorList): void{
+        versioned = new Array<e.error>();
+        const errorVersioner = new e.errorVersioner();
+        for(const normalized_e of (normalized as adltypes.errorList)){
+            const versioned_e = {} as e.error;
+            errorVersioner.Convert(normalized_e, versioned_e, errors);
+            (versioned as Array<e.error>).push(versioned_e);
+        }
+     }
+}

--- a/adl.runtime/apis/adl.apis/adl-v1/module.ts
+++ b/adl.runtime/apis/adl.apis/adl-v1/module.ts
@@ -1,0 +1,25 @@
+import * as adltypes from '@azure-tools/adl.types'
+
+import * as e from './error'
+import * as el from './errorlist'
+import * as apisnormalized from '../normalized/module'
+
+
+/**
+ *  error defines a versioned error, tools, clients (basically everything except adlruntime) should snap
+ *  to the versioened view of an error. the internal error representation (in adl.types) is meant to be used
+ *  by the machinery.
+ */
+export type error_adlv1 = adltypes.CustomApiType<'error', 'error', apisnormalized._error, e.error, e.errorVersioner>;
+
+/**
+ *  error defines a versioned errorList, tools, clients (basically everything except adlruntime) should snap
+ *  to the versioened view of an error. the internal error representation (in adl.types) is meant to be used
+ *  by the machinery.
+ */
+//!!! DON NOT USE UNTIL ADL SUPPORTS ROOT ARRAY TYPES !!!
+export type errorList_adlv1 = adltypes.CustomApiType<'errorlist', 'errorlist', apisnormalized._errorList, el.errorList, el.errorListVersioner>;
+
+
+export { errorVersioner } from './error'
+export { errorListVersioner } from './errorlist'

--- a/adl.runtime/apis/adl.apis/api-service.ts
+++ b/adl.runtime/apis/adl.apis/api-service.ts
@@ -1,0 +1,8 @@
+import * as adltypes from '@azure-tools/adl.types'
+
+
+export type apiVersion_adlv1 = adltypes.ApiVersion<"adl-v1", "adl-v1"> & adltypes.ModuleName<"adl-v1">;
+
+
+export * from './normalized/module'
+export * from './adl-v1/module'

--- a/adl.runtime/apis/adl.apis/normalized/module.ts
+++ b/adl.runtime/apis/adl.apis/normalized/module.ts
@@ -1,0 +1,49 @@
+import * as adltypes from '@azure-tools/adl.types'
+
+// exactly like adl.errors, redefining it here allows us to avoid mixed symbols
+export interface _field{
+    path: string;
+}
+export interface _error{
+    errorType :string;
+    errorMessage: string;
+    field?: _field;
+}
+
+// this works because our versioner knows how to deal with that array type
+export interface _errorList{
+
+}
+
+// noop error normalizer
+export class  errorNormalizer implements adltypes.Normalizer<_error> {
+    Default(obj: _error, errors: adltypes.errorList) : void{
+        // no op
+    }
+
+    Validate (old: _error | undefined, newObject: _error, errors: adltypes.errorList) : void{
+        // no op
+    }
+}
+export class  errorListNormalizer implements adltypes.Normalizer<_errorList> {
+    Default(obj: _errorList, errors: adltypes.errorList) : void{
+        // no op
+    }
+
+    Validate (old: _error | undefined, newObject: _errorList, errors: adltypes.errorList) : void{
+        // no op
+    }
+}
+
+/**
+ * normalized view of adl error, with a no op normalized
+ *
+ */
+export type error_normalized = adltypes.CustomNormalizedApiType<'error', _error, errorNormalizer>;
+/**
+ * normalized view of adl errorList, with a no op normalized
+ *
+ */
+//!!! DON NOT USE UNTIL ADL SUPPORTS ROOT ARRAY TYPES !!!
+
+export type errorList_normalized = adltypes.CustomNormalizedApiType<'errorlist', _errorList, errorListNormalizer>;

--- a/adl.runtime/apis/adl.apis/package.json
+++ b/adl.runtime/apis/adl.apis/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "adl.apis",
+  "version": "1.0.0",
+  "description": "",
+  "main": "api-service.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc -p .",
+    "run" : "echo 'run command is not configured'"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@azure-tools/adl.types": "~1.0.0",
+    "@azure-tools/adl.runtime": "~1.0.0",
+    "@azure-tools/arm.adl": "~1.0.0",
+    "@microsoft/ts-command-line": "4.3.10"
+  },
+  "dependencies": {
+    "@azure-tools/adl.types": "~1.0.0",
+    "@azure-tools/adl.runtime": "~1.0.0",
+    "@azure-tools/arm.adl": "~1.0.0",
+    "@microsoft/ts-command-line": "4.3.10"
+  }
+
+}

--- a/adl.runtime/apis/adl.apis/tsconfig.json
+++ b/adl.runtime/apis/adl.apis/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist/",
+    "rootDir": "./"
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "dist",
+    "resources",
+    "node_modules"
+  ]
+
+}

--- a/adl.runtime/apis/readme.md
+++ b/adl.runtime/apis/readme.md
@@ -1,0 +1,16 @@
+#What is this?
+
+This is a representation of apis used by the system using adl language. It allows for:
+
+1. Snapping an apis spec to a specific version of adl error/error list versions
+2. Snapping tools that deals with the object models (which represents ast) to snap to a public stable version, rather than the internal version that can change
+
+#What does it contain?
+
+- adl: representing adl error, errors list etc..
+- model: representing the models.
+
+#How does it work?
+
+- the entire directory is excluded from `adl.runtime` compilation
+- the apis are added to machinery and runtime during model parsing or where applicable

--- a/adl.runtime/machinery/createMachinery.ts
+++ b/adl.runtime/machinery/createMachinery.ts
@@ -1,9 +1,10 @@
-
 import * as machinerytypes from './machinery.types'
 import * as modeltypes from '../model/model.types'
 
 import { api_machinery } from './machinery'
 // main entry point
-export function CreateMachinery(opts: modeltypes.apiProcessingOptions): machinerytypes.ApiMachinery{
-    return new api_machinery(opts);
+export async function CreateMachinery(opts: modeltypes.apiProcessingOptions): Promise<machinerytypes.ApiMachinery>{
+    const machinery =  new api_machinery(opts);
+    await machinery.init();
+    return machinery;
 }

--- a/adl.runtime/machinery/machinery.types.ts
+++ b/adl.runtime/machinery/machinery.types.ts
@@ -4,8 +4,14 @@ import * as modeltypes from '../model/module'
 export const ADL_RUNTIME_NAME = "adl-core-runtime";
 // default name for runtime creator name
 export const DEFAULT_RUNTIME_CREATOR_TYPE_NAME = "RuntimeCreator";
-// loadable runtime types
 
+// api name for adl apis
+export const ADL_APIS_NAME = "adl.apis"
+// default version for adl-apis
+export const DEFAULT_ADL_APIS_VERSION = "adl-v1";
+export const ADL_APIS_ERROR_TYPE_NAME = "error";
+export const ADL_APIS_ERRORLIST_TYPE_NAME = "errorlist";
+// loadable runtime types
 // represents a loadable runtime
 export class machineryLoadableRuntime{
     get Name(): string{return this._name;}
@@ -305,4 +311,7 @@ export interface ApiMachinery{
 
     // creates a runtime instance for store
     createRuntime(store: ApiManager): ApiRuntime;
+
+    convertToVersioendError(error: adltypes.error, versionName: string):any;
+    convertToVersioendErrorList(errors: adltypes.errorList, versionName: string): any;
 }

--- a/adl.runtime/machinery/runtime.ts
+++ b/adl.runtime/machinery/runtime.ts
@@ -1072,7 +1072,7 @@ export class apiRuntime implements machinerytypes.ApiRuntime{
 
         // api won't load if the reference by name does not exist.
         const normalizedTypeModel = apiModel.getNormalizedApiType(versionedTypeModel.NormalizedApiTypeName) as modeltypes.NormalizedApiTypeModel;
-        const versionedTyped =  adltypes.isComplex(payload) ? payload : JSON.parse(payload);
+        const versionedTyped =  ("string" !== typeof payload) ? payload : JSON.parse(payload);
         const rootField = adltypes.getRootFieldDesc();
 
         /* TODO: @khenidak optimize
@@ -1125,7 +1125,7 @@ export class apiRuntime implements machinerytypes.ApiRuntime{
 
         // api won't load if the reference by name does not exist.
         const normalizedTypeModel = apiModel.getNormalizedApiType(versionedTypeModel.NormalizedApiTypeName) as modeltypes.NormalizedApiTypeModel;
-        const normalizedTyped = adltypes.isComplex(normalizedPayload) ? normalizedPayload : JSON.parse(normalizedPayload);
+        const normalizedTyped = ("string" !== typeof normalizedPayload) ? normalizedPayload : JSON.parse(normalizedPayload);
 
         const rootField = adltypes.getRootFieldDesc();
 

--- a/adl.runtime/model/model.types.ts
+++ b/adl.runtime/model/model.types.ts
@@ -350,26 +350,31 @@ class apiProcessingConsoleLogger implements apiProcessingLogger{
 
 // ApiLoadOptions logger, log level and other
 // settings used in processing (validation, loading etc).
+// TODO: move to a location outside models
 export class apiProcessingOptions{
-        // default log level none
-        private _logLevel: apiProcessingLogLevel = apiProcessingLogLevel.err;
-        private _logger: apiProcessingLogger;
+    // default log level none
+    private _logLevel: apiProcessingLogLevel = apiProcessingLogLevel.err;
+    private _logger: apiProcessingLogger;
 
-        constructor()
-        constructor(logLevel?: apiProcessingLogLevel)
-        constructor(logLevel?: apiProcessingLogLevel, logger?:apiProcessingLogger){
-            if(logLevel)
-                this._logLevel = logLevel;
+    // if true, the machinery will load adl types
+    // should be used set if the application is expected to use the macnhinery
+    // to convert adl own types(error/errorList) to versioned types
+    loadAdlApis: boolean;
 
-            if(logger){
-                this._logger = logger
-                return;
-            }
+    constructor()
+    constructor(logLevel?: apiProcessingLogLevel)
+    constructor(logLevel?: apiProcessingLogLevel, logger?:apiProcessingLogger){
+        if(logLevel) this._logLevel = logLevel;
 
-            this._logger = new apiProcessingConsoleLogger(this._logLevel);
-        }
+        if(logger){
+            this._logger = logger
+            return;
+         }
 
-        get logger(): apiProcessingLogger{
-            return this._logger;
-        }
+        this._logger = new apiProcessingConsoleLogger(this._logLevel);
+    }
+
+    get logger(): apiProcessingLogger{
+        return this._logger;
+    }
 }

--- a/adl.runtime/tsconfig.json
+++ b/adl.runtime/tsconfig.json
@@ -10,11 +10,10 @@
     "types" : ["node"]
    },
   "include": [
-    "./index.ts",
-    "./model/**/*",
-    "./serialization/**/*"
+    "./index.ts"
   ],
   "exclude": [
+    "apis",
     "dist",
     "test/scenarios/**",
     "resources",

--- a/adl.types/utils/utils.ts
+++ b/adl.types/utils/utils.ts
@@ -28,7 +28,7 @@ export function  getRootFieldDesc(): adltypes.fieldDesc{
 // KNOWN ERRORS
 export function createKnownError_MissingProperty(fieldDesc: adltypes.fieldDesc): adltypes.error{
     const e =  new adltypes.error();
-    e.errorMessage = `an non-optional ${fieldDesc.name} property is missing [${fieldDesc.path}]`;
+    e.errorMessage = `an non-optional ${fieldDesc.name} property is missing`;
     e.errorType = "validation";
     e.field = fieldDesc;
     return e;
@@ -36,7 +36,7 @@ export function createKnownError_MissingProperty(fieldDesc: adltypes.fieldDesc):
 
 export function createKnownError_ExtraProperty(fieldDesc: adltypes.fieldDesc): adltypes.error{
     const e =  new adltypes.error();
-    e.errorMessage = `unknown property ${fieldDesc.name} [${fieldDesc.path}]`;
+    e.errorMessage = `unknown property ${fieldDesc.name}`;
     e.errorType = "validation";
     e.field = fieldDesc;
     return e;

--- a/cli/src/cmd_machinery.ts
+++ b/cli/src/cmd_machinery.ts
@@ -3,8 +3,9 @@ import fs from 'fs';
 
 import { CommandLineAction, CommandLineStringParameter, CommandLineChoiceParameter } from '@microsoft/ts-command-line'
 import { appContext } from './appContext'
-import * as adltypes from '@azure-tools/adl.types'
+import * as cliutils from './utils'
 
+import * as adltypes from '@azure-tools/adl.types'
 /* shows what is in store
  * in a runtime env, this will connect to rpaas api server
  * and use it as a store, to red api definitions from
@@ -125,12 +126,12 @@ export class machineryAction extends CommandLineAction {
         const apiName = this._apiName.value as string;
         const normalizedApiTypeName = this._normalizedApiTypeName.value as string;
 
-            const normalized = runtime.create_normalized_instance(apiName, normalizedApiTypeName);
-            console.log(JSON.stringify(normalized));/*TODO printers*/
-
-            return;
+        const normalized = runtime.create_normalized_instance(apiName, normalizedApiTypeName);
+        console.log(JSON.stringify(normalized));/*TODO printers*/
     }
 
+    //  if s is path, it returns the file in path
+    // if not, s is returned
     private getFromSource(s:string): string {
         if(resolve(s)){
             return fs.readFileSync(s).toString();
@@ -152,13 +153,7 @@ export class machineryAction extends CommandLineAction {
             throw new Error(`failed to read data from ${source}`)
 
         const normalized = runtime.normalize(versionedTyped, apiName, versionName, versionedApiTypeName, errors);
-        if(errors.length > 0){
-            //TODO set process exist code
-            console.log(JSON.stringify(errors)); //TODO printers
-            return;
-        }
-
-            console.log(JSON.stringify(normalized));
+        cliutils.printResultOrError(this.ctx, normalized, errors, true /*exit*/);
     }
 
     private denormalize(){
@@ -175,13 +170,7 @@ export class machineryAction extends CommandLineAction {
             throw new Error(`failed to read data from ${source}`)
 
         const versioned = runtime.denormalize(normalizedTyped, apiName, tgtVersionName, tgtversionedApiTypeName, errors);
-        if(errors.length > 0){
-            //TODO set process exist code
-            console.log(JSON.stringify(errors)); //TODO printers
-            return;
-        }
-
-        console.log(JSON.stringify(versioned));
+        cliutils.printResultOrError(this.ctx, versioned, errors, true /*exit*/);
     }
 
     private convert(){
@@ -203,15 +192,9 @@ export class machineryAction extends CommandLineAction {
             throw new Error(`failed to read data from ${source}`);
 
         const tgtversioned = runtime.convert(srcVersionedTyped, apiName, versionName, versionedApiTypeName, tgtVersionName, tgtversionedApiTypeName ,errors);
-        if(errors.length > 0){
-            //TODO set process exist code
-            console.log(JSON.stringify(errors)); //TODO printers
-            return;
-        }
-
-        console.log(JSON.stringify(tgtversioned));
-
+        cliutils.printResultOrError(this.ctx, tgtversioned, errors, true /*exit*/);
     }
+
     protected onExecute(): Promise<void> { // abstract
         return new Promise<void>( () => {
             const runtime = this.ctx.machineryRuntime;

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -63,12 +63,13 @@ export class adlCliParser extends CommandLineParser {
         const ctx = this.ctx;
         // create opts
         ctx.opts = new adlruntime.apiProcessingOptions();
+        ctx.opts.loadAdlApis = true; //we will be converting errors, and we load adl apis spec
 
         // wire up log level
         ctx.opts.logger.logLevel = adlruntime.apiProcessingLogLevel[this._log_level.value as string];
 
         // create the machinery using our opts
-        const machinery = adlruntime.CreateMachinery(ctx.opts);
+        const machinery = await adlruntime.CreateMachinery(ctx.opts);
         // keep it in context
         ctx.machinery = machinery
         // use it to create an api manager (store)

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1,0 +1,25 @@
+import { appContext } from './appContext'
+import * as adltypes from '@azure-tools/adl.types'
+
+
+// our cli snaps to this version
+export const DEFAULT_CLI_ADL_API_VERSION_NAME = "adl-v1";
+
+// if errors has error(s), it will print and set exit code accordingly
+export function printResultOrError(ctx: appContext, result: any, errors:adltypes.errorList, exit: boolean /*TODO: add printers*/):void{
+    if(errors.length > 0){
+        // TODO: when adl supports root array type, drop this and use errorList convertor
+        const versioned_errorList = new Array<any>();
+        for(const e of errors){
+            const versioned_error = ctx.machinery.convertToVersioendError(e, DEFAULT_CLI_ADL_API_VERSION_NAME);
+            versioned_errorList.push(versioned_error);
+        }
+        console.log(JSON.stringify(versioned_errorList));
+        if(exit)
+            process.exit(99);
+        return;
+     }
+
+    console.log(JSON.stringify(result));
+}
+

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -3,12 +3,13 @@ dependencies:
   '@azure-tools/codegen': 2.1.230
   '@azure-tools/linq': 3.1.217
   '@microsoft/ts-command-line': 4.3.10
+  '@rush-temp/adl.apis': 'file:projects/adl.apis.tgz'
   '@rush-temp/adl.runtime': 'file:projects/adl.runtime.tgz'
   '@rush-temp/adl.types': 'file:projects/adl.types.tgz'
   '@rush-temp/arm.adl': 'file:projects/arm.adl.tgz'
   '@rush-temp/cli': 'file:projects/cli.tgz'
-  '@rush-temp/sample_rp': 'file:projects/sample_rp.tgz'
   '@rush-temp/compute_rp': 'file:projects/compute_rp.tgz'
+  '@rush-temp/sample_rp': 'file:projects/sample_rp.tgz'
   '@types/js-yaml': 3.12.1
   '@typescript-eslint/eslint-plugin': 2.16.0
   '@typescript-eslint/parser': 2.16.0
@@ -170,11 +171,15 @@ packages:
       eslint: ^5.0.0 || ^6.0.0
     resolution:
       integrity: sha512-TKWbeFAKRPrvKiR9GNxErQ8sELKqg1ZvXi6uho07mcKShBnCnqNpDQWP01FEvWKf0bxM2g7uQEI5MNjSNqvUpQ==
-  /@typescript-eslint/eslint-plugin/2.16.0/@typescript-eslint!parser@2.16.0:
+  /@typescript-eslint/eslint-plugin/2.16.0/894af94b56f455770564ef7826675546:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.16.0
-      '@typescript-eslint/parser': 2.16.0
-      tsutils: 3.17.1
+      '@typescript-eslint/experimental-utils': /@typescript-eslint/experimental-utils/2.16.0/eslint@6.8.0
+      '@typescript-eslint/parser': /@typescript-eslint/parser/2.16.0/eslint@6.8.0
+      eslint: 6.8.0
+      eslint-utils: 1.4.3
+      functional-red-black-tree: 1.0.1
+      regexpp: 3.0.0
+      tsutils: /tsutils/3.17.1/typescript@3.7.5
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -196,6 +201,20 @@ packages:
       eslint: '*'
     resolution:
       integrity: sha512-bXTmAztXpqxliDKZgvWkl+5dHeRN+jqXVZ16peKKFzSXVzT6mz8kgBpHiVzEKO2NZ8OCU7dG61K9sRS/SkUUFQ==
+  /@typescript-eslint/experimental-utils/2.16.0/eslint@6.8.0:
+    dependencies:
+      '@types/json-schema': 7.0.4
+      '@typescript-eslint/typescript-estree': 2.16.0
+      eslint: 6.8.0
+      eslint-scope: 5.0.0
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    id: registry.npmjs.org/@typescript-eslint/experimental-utils/2.16.0
+    peerDependencies:
+      eslint: '*'
+    resolution:
+      integrity: sha512-bXTmAztXpqxliDKZgvWkl+5dHeRN+jqXVZ16peKKFzSXVzT6mz8kgBpHiVzEKO2NZ8OCU7dG61K9sRS/SkUUFQ==
   /@typescript-eslint/parser/2.16.0:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
@@ -205,6 +224,21 @@ packages:
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0
+    resolution:
+      integrity: sha512-+w8dMaYETM9v6il1yYYkApMSiwgnqXWJbXrA94LAWN603vXHACsZTirJduyeBOJjA9wT6xuXe5zZ1iCUzoxCfw==
+  /@typescript-eslint/parser/2.16.0/eslint@6.8.0:
+    dependencies:
+      '@types/eslint-visitor-keys': 1.0.0
+      '@typescript-eslint/experimental-utils': /@typescript-eslint/experimental-utils/2.16.0/eslint@6.8.0
+      '@typescript-eslint/typescript-estree': 2.16.0
+      eslint: 6.8.0
+      eslint-visitor-keys: 1.1.0
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    id: registry.npmjs.org/@typescript-eslint/parser/2.16.0
     peerDependencies:
       eslint: ^5.0.0 || ^6.0.0
     resolution:
@@ -1586,6 +1620,18 @@ packages:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     resolution:
       integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  /tsutils/3.17.1/typescript@3.7.5:
+    dependencies:
+      tslib: 1.10.0
+      typescript: 3.7.5
+    dev: false
+    engines:
+      node: '>= 6'
+    id: registry.npmjs.org/tsutils/3.17.1
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    resolution:
+      integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   /type-check/0.3.2:
     dependencies:
       prelude-ls: 1.1.2
@@ -1694,6 +1740,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==
+  'file:projects/adl.apis.tgz':
+    dependencies:
+      '@microsoft/ts-command-line': 4.3.10
+    dev: false
+    name: '@rush-temp/adl.apis'
+    resolution:
+      integrity: sha512-8Y2Wjf763VRmXx08kl3RVNEwfYd9+KmNZa/sU5HeusA3fhDENgF9D/TbjFZ7s96RarSaeg6bdtw+htZ5wMdjUA==
+      tarball: 'file:projects/adl.apis.tgz'
+    version: 0.0.0
   'file:projects/adl.runtime.tgz':
     dependencies:
       '@azure-tools/async-io': 3.0.211
@@ -1703,8 +1758,8 @@ packages:
       '@types/js-yaml': 3.12.1
       '@types/mocha': 5.2.5
       '@types/node': 12.7.2
-      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.16.0/@typescript-eslint!parser@2.16.0
-      '@typescript-eslint/parser': 2.16.0
+      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.16.0/894af94b56f455770564ef7826675546
+      '@typescript-eslint/parser': /@typescript-eslint/parser/2.16.0/eslint@6.8.0
       eslint: 6.8.0
       js-yaml: 3.13.1
       mocha: 5.2.0
@@ -1721,8 +1776,8 @@ packages:
   'file:projects/adl.types.tgz':
     dependencies:
       '@types/node': 12.7.2
-      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.16.0/@typescript-eslint!parser@2.16.0
-      '@typescript-eslint/parser': 2.16.0
+      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.16.0/894af94b56f455770564ef7826675546
+      '@typescript-eslint/parser': /@typescript-eslint/parser/2.16.0/eslint@6.8.0
       eslint: 6.8.0
       typescript: 3.7.5
     dev: false
@@ -1734,14 +1789,14 @@ packages:
   'file:projects/arm.adl.tgz':
     dependencies:
       '@types/node': 12.7.2
-      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.16.0/@typescript-eslint!parser@2.16.0
-      '@typescript-eslint/parser': 2.16.0
+      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.16.0/894af94b56f455770564ef7826675546
+      '@typescript-eslint/parser': /@typescript-eslint/parser/2.16.0/eslint@6.8.0
       eslint: 6.8.0
       typescript: 3.7.5
     dev: false
     name: '@rush-temp/arm.adl'
     resolution:
-      integrity: sha512-5neZhdwMImA7kgRmD2EUmPtpHD0AvlcesNf6zzGkwKvdsUb+Y+MvrjFeZtNl8HtKVXWIg3s/MehSodZ5SJySbQ==
+      integrity: sha512-CGtGLC+61WmOC+sFDc0i5YENZ6f7VvxkcLYk77s50fkEVDRRX94GJ3PkIwDreT/jX5Qiu5k1iZhDmy7n3uT44g==
       tarball: 'file:projects/arm.adl.tgz'
     version: 0.0.0
   'file:projects/cli.tgz':
@@ -1754,6 +1809,15 @@ packages:
       integrity: sha512-6ZL6JUhdNH4TXdXNXyEmIx6b88uQIy4gz6nka4myevYQn+/5zPUvTu8sy6amm3CnDOUX8YczGRM9VKyetkXNZw==
       tarball: 'file:projects/cli.tgz'
     version: 0.0.0
+  'file:projects/compute_rp.tgz':
+    dependencies:
+      '@microsoft/ts-command-line': 4.3.10
+    dev: false
+    name: '@rush-temp/compute_rp'
+    resolution:
+      integrity: sha512-BVDQQBmBRvDcbnBrdO6TmqbHqXnOug7CQaPcAVQWMnooN4Fikf7mRCZpcsXr43pwjLpfCts0YTFXgx317YEQGw==
+      tarball: 'file:projects/compute_rp.tgz'
+    version: 0.0.0
   'file:projects/sample_rp.tgz':
     dependencies:
       '@microsoft/ts-command-line': 4.3.10
@@ -1763,14 +1827,6 @@ packages:
       integrity: sha512-/3A28/GrcHoobFTg7YCCjmN0bmeTkxZnu/JoilUgXBom6O1u9TA9HFUPcP6UgJ0f8uy2zcloSCFpDvolSZ8Z4w==
       tarball: 'file:projects/sample_rp.tgz'
     version: 0.0.0
-  'file:projects/compute_rp.tgz':
-    dependencies:
-      '@microsoft/ts-command-line': 4.3.10
-    dev: false
-    name: '@rush-temp/compute_rp'
-    resolution:
-      tarball: 'file:projects/compute_rp.tgz'
-    version: 0.0.0
 registry: 'https://registry.npmjs.org/'
 shrinkwrapMinorVersion: 9
 shrinkwrapVersion: 3
@@ -1779,12 +1835,13 @@ specifiers:
   '@azure-tools/codegen': ~2.1.0
   '@azure-tools/linq': ~3.1.0
   '@microsoft/ts-command-line': 4.3.10
+  '@rush-temp/adl.apis': 'file:./projects/adl.apis.tgz'
   '@rush-temp/adl.runtime': 'file:./projects/adl.runtime.tgz'
   '@rush-temp/adl.types': 'file:./projects/adl.types.tgz'
   '@rush-temp/arm.adl': 'file:./projects/arm.adl.tgz'
   '@rush-temp/cli': 'file:./projects/cli.tgz'
-  '@rush-temp/sample_rp': 'file:./projects/sample_rp.tgz'
   '@rush-temp/compute_rp': 'file:./projects/compute_rp.tgz'
+  '@rush-temp/sample_rp': 'file:./projects/sample_rp.tgz'
   '@types/js-yaml': 3.12.1
   '@typescript-eslint/eslint-plugin': ~2.16.0
   '@typescript-eslint/parser': ~2.16.0

--- a/rush.json
+++ b/rush.json
@@ -373,6 +373,13 @@
       "projectFolder": "compute_rp",
       "reviewCategory": "production",
       "shouldPublish": true
+    },
+    {
+      "packageName": "adl.apis",
+      "projectFolder": "adl.runtime/apis/adl.apis",
+      "reviewCategory": "production",
+      "shouldPublish": false
     }
+
   ]
 }


### PR DESCRIPTION
adds adl apis (error/errorlist) as adl spec'ed apis. The apis are loaded when `processingOptions.loadAdlApis` is set to true. This is needed by the likes of CLI that. 

Additional work remaining on this feature (after 29th):
- Add Model APIs
- Add support to snap a user provided spec (api version) to adlapis
- Modify errorList once ADL supports array types at the top level  