### PR TITLE
[Printer Part 1] Refactor printer

### DIFF
--- a/cli/src/cmd_showstore.ts
+++ b/cli/src/cmd_showstore.ts
@@ -30,16 +30,18 @@ export class showStoreAction extends CommandLineAction {
     private _filter: CommandLineStringParameter; /* TODO */
     private _show_docs: CommandLineFlagParameter;
     
-    private readonly _output_format: string;
+    private _output_format: string;
 
-    public constructor(private ctx: appContext, outputFormat: string) {
+    public constructor(private ctx: appContext) {
     super({
       actionName: 'list',
       summary: 'shows the apis already loaded in the store',
       documentation: ''
     });
+  }
 
-    this._output_format = outputFormat;
+  public setOutputFormat(outputFormat: string) {
+      this._output_format = outputFormat;
   }
 
   private getPrinter(): printer {

--- a/cli/src/cmd_showstore.ts
+++ b/cli/src/cmd_showstore.ts
@@ -2,6 +2,8 @@ import { CommandLineAction, CommandLineChoiceParameter, CommandLineFlagParameter
 import { appContext } from './appContext'
 
 import * as adlruntime from '@azure-tools/adl.runtime'
+import { printer } from './printers/printer';
+import { textPrinter } from './printers/text_printer';
 
 /* shows what is in store
  * in a runtime env, this will connect to rpaas api server
@@ -27,129 +29,31 @@ export class showStoreAction extends CommandLineAction {
     private _scope: CommandLineChoiceParameter;
     private _filter: CommandLineStringParameter; /* TODO */
     private _show_docs: CommandLineFlagParameter;
+    
+    private readonly _output_format: string;
 
-    private getPropertiesConstraintsAsText(p: adlruntime.ApiTypePropertyModel): string{
-        let constraintsAsText = ""
-        if(!p.isEnum){
-            for(const c of p.Constraints){
-                constraintsAsText = `${constraintsAsText} | ${c.Name}(${c.Arguments.join(",")})`;
-            }
-            return constraintsAsText;
-        }
-        constraintsAsText = `enum${p.EnumValues}`;
-        return constraintsAsText;
-    }
-    private printDocs(prefix: string, docs: adlruntime.ApiJsDoc | undefined){
-        if(docs == undefined || this._show_docs.value == false) return;
-        console.log(` ${prefix}docs:`)
-        for(const l of docs.text.split("\n"))
-            console.log(`  ${prefix}${l}`);
-
-        console.log(` ${prefix}tags:`)
-        for(const [k,v] of docs.tags){
-            console.log(`  ${prefix}${k}: ${v}`)
-        }
-    }
-
-    private printModel(scope: string, model: adlruntime.ApiModel):void{
-        // Print api model name
-        var prefix = "";
-        console.log(`${prefix} Api Model: ${model.Name}`);
-    }
-
-    private printApiTypeModel(prefix: string, model:adlruntime.ApiTypeModel): void{
-        // properties
-        for(const prop  of model.Properties){
-            if(prop.isRemoved) return;
-            console.log(`${prefix} Property:${prop.Name}(${prop.DataTypeName}/${prop.AliasDataTypeName}) ${this.getPropertiesConstraintsAsText(prop)}`);
-            if(prop.DataTypeKind == adlruntime.PropertyDataTypeKind.Complex ||
-                prop.DataTypeKind == adlruntime.PropertyDataTypeKind.ComplexArray ||
-                prop.DataTypeKind == adlruntime.PropertyDataTypeKind.ComplexMap){
-                    this.printDocs(` ${prefix}`, prop.Docs);
-                    this.printApiTypeModel(prefix + " ", prop.getComplexDataTypeOrThrow())
-            }
-            if(prop.isMap()){
-                let constraintAsText = ""
-                for(const c of prop.MapKeyConstraints){
-                    constraintAsText = constraintAsText + `${c.Name}(` + c.Arguments.join(",") +") | ";
-                }
-
-                if(constraintAsText.length > 0)
-                    console.log(`${prefix} * KeyConstraints: ${constraintAsText}`);
-
-                constraintAsText = ""
-                for(const c of prop.MapValueConstraints){
-                    constraintAsText = constraintAsText + `${c.Name}(` + c.Arguments.join(",") +") | ";
-                }
-                if(constraintAsText.length > 0)
-                    console.log(`${prefix} * ValueConstraints: ${constraintAsText}`);
-            }
-        }
-    }
-    private printNormalizedTypes(scope:string, normalizedTypes: Iterable<adlruntime.NormalizedApiTypeModel>): void{
-        if(scope != "all" && scope != "normalized") return;
-        var prefix = "";
-        // normalized types
-        console.log(`${prefix} Normalized Types:`);
-        for(const normalizedType of normalizedTypes){
-            prefix = "  ";
-            let constraintsAsText = ""
-            for(const c of normalizedType.Constraints){
-                constraintsAsText = constraintsAsText + c.Name + "\t"
-            }
-            if(constraintsAsText.length > 0){
-                constraintsAsText = "> " + constraintsAsText;
-            }
-            console.log(`${prefix} + Type: ${normalizedType.Name} ${constraintsAsText}`);
-            this.printDocs(` ${prefix}`, normalizedType.Docs);
-            prefix = "    ";
-            this.printApiTypeModel(prefix, normalizedType);
-       }
-    }
-
-    private printApiVersions(scope: string, apiVersions: Iterable<adlruntime.ApiVersionModel>):void{
-        var prefix = "";
-        if(scope != "all" && scope != "api-versions" && scope != "versioned") return;
-            // api versions
-            console.log(`${prefix} Versions:`);
-            for(let apiVersion of apiVersions){
-                prefix = "  ";
-                console.log(`${prefix} + api-version: ${apiVersion.Name}`);
-                this.printDocs(`  ${prefix}`, apiVersion.Docs);
-                this.printVersionedTypes(scope, apiVersion.VersionedTypes);
-            }
-    }
-
-    private printVersionedTypes(scope: string, versionedTypes: Iterable<adlruntime.VersionedApiTypeModel>):void{
-        var prefix = "";
-        // types in version
-        if(scope != "all" && scope != "versioned") return;
-        for(const versionedType of versionedTypes){
-            prefix = "    ";
-            let constraintsAsText = ""
-            for(const c of versionedType.Constraints){
-                constraintsAsText = constraintsAsText + c.Name + "\t"
-            }
-
-            if(constraintsAsText.length > 0){
-                constraintsAsText = "> " + constraintsAsText;
-            }
-
-            console.log(`${prefix} Type:${versionedType.Name} ${constraintsAsText}`);
-            this.printDocs(` ${prefix}`, versionedType.Docs);
-            prefix = "     ";
-            this.printApiTypeModel(prefix, versionedType);
-        }
-    }
-
-    public constructor(private ctx: appContext) {
+    public constructor(private ctx: appContext, outputFormat: string) {
     super({
       actionName: 'list',
       summary: 'shows the apis already loaded in the store',
       documentation: ''
     });
+
+    this._output_format = outputFormat;
   }
 
+  private getPrinter(): printer {
+      switch (this._output_format) {
+          case 'text': {
+              return new textPrinter(this._scope.value ?? 'all', this._show_docs.value);
+              break;
+          }
+          default: {
+              return new textPrinter(this._scope.value ?? 'all', this._show_docs.value);
+              break;
+          }
+      }
+  }
 
   protected onExecute(): Promise<void> {
             // TODO: pretty print, json yaml printing etc.
@@ -158,12 +62,15 @@ export class showStoreAction extends CommandLineAction {
 
                 // dumb print information from store as is
                 var models = this.ctx.store.ApiModels;
+
+                var printer = this.getPrinter();
                 // api infos
                 for(let model of models){
-                        this.printModel(scope, model);
-                        this.printNormalizedTypes(scope, model.NormalizedTypes);
-                        this.printApiVersions(scope, model.Versions);
+                        printer.printModel(model);
+                        printer.printNormalizedTypes(model.NormalizedTypes);
+                        printer.printApiVersions(model.Versions);
                     }
+                printer.flushOutput();
             });
   }
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -26,7 +26,7 @@ export class adlCliParser extends CommandLineParser {
     });
 
     //  pass context down the line
-    this.addAction(new showStoreAction(ctx, this._output_format.value ?? 'text'));
+    this.addAction(new showStoreAction(ctx));
     this.addAction(new diffAction(ctx));
     this.addAction(new verifyConformanceAction(ctx));
     this.addAction(new machineryAction(ctx));
@@ -84,6 +84,8 @@ export class adlCliParser extends CommandLineParser {
         // use it to create an api manager (store)
         ctx.store = machinery.createApiManager();
 
+        // setup output format
+        (<showStoreAction>this.getAction("list")).setOutputFormat(this._output_format.value ?? "text");
 
         // loadable runtimes
         const runtimes = this._pre_load_runtime.values;

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -15,7 +15,7 @@ export class adlCliParser extends CommandLineParser {
     private _log_level: CommandLineChoiceParameter;
     private _pre_load_api: CommandLineStringListParameter;
     private _pre_load_runtime: CommandLineStringListParameter;
-
+    private _output_format: CommandLineChoiceParameter;
 
     // TODO: use  printer that can do json/yaml or just pretty print
 
@@ -26,7 +26,7 @@ export class adlCliParser extends CommandLineParser {
     });
 
     //  pass context down the line
-    this.addAction(new showStoreAction(ctx));
+    this.addAction(new showStoreAction(ctx, this._output_format.value ?? 'text'));
     this.addAction(new diffAction(ctx));
     this.addAction(new verifyConformanceAction(ctx));
     this.addAction(new machineryAction(ctx));
@@ -54,6 +54,15 @@ export class adlCliParser extends CommandLineParser {
             parameterLongName: '--pre-load-runtimes',
             description: 'list of runtimes to preload each is path=<path> (assumes runtime use default runtime creator type name)',
             argumentName: 'LIST_RUNTIMES',
+        });
+
+        this._output_format = this.defineChoiceParameter({
+            parameterLongName: '--output',
+            parameterShortName: '-o',
+            alternatives: [ 'text' ],
+            defaultValue: 'text',
+            description: 'output format',
+            required: false,
         });
 
   }

--- a/cli/src/printers/printer.ts
+++ b/cli/src/printers/printer.ts
@@ -1,0 +1,9 @@
+import * as adlruntime from '@azure-tools/adl.runtime'
+
+export interface printer {
+  printModel(model: adlruntime.ApiModel): void;
+  printNormalizedTypes(normalizedTypes: Iterable<adlruntime.NormalizedApiTypeModel>): void;
+  printApiVersions(apiVersions: Iterable<adlruntime.ApiVersionModel>): void;
+  printDocs(docs: adlruntime.ApiJsDoc | undefined): void;
+  flushOutput(): void;
+}

--- a/cli/src/printers/text_printer.ts
+++ b/cli/src/printers/text_printer.ts
@@ -1,0 +1,150 @@
+import { printer } from './printer'
+
+import * as adlruntime from '@azure-tools/adl.runtime'
+
+export class textPrinter implements printer {
+  private readonly _scope: string;
+  private readonly _show_docs: boolean;
+  private _prefix: string;
+
+  public constructor(scope: string, showDocs: boolean) {
+    this._scope = scope;
+    this._show_docs = showDocs;
+    this._prefix = "";
+  }
+
+  public printModel(model: adlruntime.ApiModel): void {
+    // Print api model name
+    this._prefix = "";
+    console.log(`${this._prefix} Api Model: ${model.Name}`);
+  }
+
+  public printNormalizedTypes(normalizedTypes: Iterable<adlruntime.NormalizedApiTypeModel>): void {
+    if(this._scope != "all" && this._scope != "normalized") return;
+
+    this._prefix = "";
+    // normalized types
+    console.log(`${this._prefix} Normalized Types:`);
+    for(const normalizedType of normalizedTypes){
+        this._prefix = "  ";
+        let constraintsAsText = "";
+        for(const c of normalizedType.Constraints){
+            constraintsAsText = constraintsAsText + c.Name + "\t"
+        }
+        if(constraintsAsText.length > 0){
+            constraintsAsText = "> " + constraintsAsText;
+        }
+        console.log(`${this._prefix} + Type: ${normalizedType.Name} ${constraintsAsText}`);
+        
+        this.printDocs(normalizedType.Docs);
+        
+        this._prefix = "    ";
+        
+        this.printApiTypeModel(normalizedType);
+    }
+  }
+
+  public printApiVersions(apiVersions: Iterable<adlruntime.ApiVersionModel>): void {
+    if(this._scope != "all" && this._scope != "api-versions" && this._scope != "versioned") return;
+    
+    // api versions
+    console.log(`${this._prefix} Versions:`);
+    for(let apiVersion of apiVersions){
+        this._prefix = "  ";
+        console.log(`${this._prefix} + api-version: ${apiVersion.Name}`);
+        this.printDocs(apiVersion.Docs);
+        this.printVersionedTypes(apiVersion.VersionedTypes);
+    }
+  }
+
+  public printDocs(docs: adlruntime.ApiJsDoc | undefined): void {
+    if (!this._show_docs) return;
+    if(docs == undefined) return;
+    console.log(` ${this._prefix}docs:`)
+    for(const l of docs.text.split("\n")) {
+        console.log(`  ${this._prefix}${l}`);
+    }
+
+    console.log(` ${this._prefix}tags:`)
+    for(const [k,v] of docs.tags){
+        console.log(`  ${this._prefix}${k}: ${v}`)
+    }
+  }
+
+  public flushOutput(): void {
+    this._prefix = "";
+    return;
+  }
+
+  /*
+   * Private methods
+   */
+
+  private printApiTypeModel(model:adlruntime.ApiTypeModel): void {
+    for(const prop  of model.Properties){
+      if(prop.isRemoved) return;
+      console.log(`${this._prefix} Property:${prop.Name}(${prop.DataTypeName}/${prop.AliasDataTypeName}) ${this.getPropertiesConstraintsAsText(prop)}`);
+      if(prop.DataTypeKind == adlruntime.PropertyDataTypeKind.Complex ||
+          prop.DataTypeKind == adlruntime.PropertyDataTypeKind.ComplexArray ||
+          prop.DataTypeKind == adlruntime.PropertyDataTypeKind.ComplexMap){
+              this.printDocs(prop.Docs);
+              this._prefix += " ";
+              this.printApiTypeModel(prop.getComplexDataTypeOrThrow());
+              this._prefix = this._prefix.slice(0, -1);
+      }
+      if(prop.isMap()){
+          let constraintAsText = ""
+          for(const c of prop.MapKeyConstraints){
+              constraintAsText = constraintAsText + `${c.Name}(` + c.Arguments.join(",") +") | ";
+          }
+
+          if(constraintAsText.length > 0)
+              console.log(`${this._prefix} * KeyConstraints: ${constraintAsText}`);
+
+          constraintAsText = ""
+          for(const c of prop.MapValueConstraints){
+              constraintAsText = constraintAsText + `${c.Name}(` + c.Arguments.join(",") +") | ";
+          }
+
+          if(constraintAsText.length > 0)
+              console.log(`${this._prefix} * ValueConstraints: ${constraintAsText}`);
+      }
+    }
+  }
+
+  private getPropertiesConstraintsAsText(p: adlruntime.ApiTypePropertyModel): string {
+    let constraintsAsText = ""
+    if(!p.isEnum){
+        for(const c of p.Constraints){
+            constraintsAsText = `${constraintsAsText} | ${c.Name}(${c.Arguments.join(",")})`;
+        }
+        return constraintsAsText;
+    }
+    constraintsAsText = `enum${p.EnumValues}`;
+    return constraintsAsText;
+  }
+
+  private printVersionedTypes(versionedTypes: Iterable<adlruntime.VersionedApiTypeModel>): void {
+    if(this._scope != "all" && this._scope != "versioned") return;
+    
+    this._prefix = "";
+
+    // types in version    
+    for(const versionedType of versionedTypes){
+        this._prefix = "    ";
+        let constraintsAsText = ""
+        for(const c of versionedType.Constraints){
+            constraintsAsText = constraintsAsText + c.Name + "\t"
+        }
+
+        if(constraintsAsText.length > 0){
+            constraintsAsText = "> " + constraintsAsText;
+        }
+
+        console.log(`${this._prefix} Type:${versionedType.Name} ${constraintsAsText}`);
+        this.printDocs(versionedType.Docs);
+        this._prefix = "     ";
+        this.printApiTypeModel(versionedType);
+    }
+  }
+}


### PR DESCRIPTION
First pull request for table printer.

In this PR, `cmd_show_store` is refactored so that it could use a `--output=text` parameter to choose which printer to use.