### PR TITLE
Disable source tracking, remove target tracking entirely

### DIFF
--- a/adl/core/.eslintignore
+++ b/adl/core/.eslintignore
@@ -1,2 +1,3 @@
 **/*.d.ts
 test/scenarios/**
+yarn/*.js

--- a/adl/core/model/api-model.ts
+++ b/adl/core/model/api-model.ts
@@ -1,6 +1,6 @@
 import { exists, isFile, mkdir, rmdir, writeFile } from '@azure-tools/async-io';
-import { Dictionary, values } from '@azure-tools/linq';
-import { isAnonymous, Path, SourceMap, TargetMap, use, valueOf } from '@azure-tools/sourcemap';
+import { Dictionary } from '@azure-tools/linq';
+import { isAnonymous, Path, valueOf } from '@azure-tools/sourcemap';
 import { dirname, join } from 'path';
 import { EnumDeclaration, IndentationText, NewLineKind, Node, Project, QuoteKind, SourceFile } from 'ts-morph';
 import { getNode, referenceTo } from '../support/typescript';
@@ -36,14 +36,7 @@ export class ApiModel {
     group: this.#project.createDirectory('operations'),
     resource: this.#project.createDirectory('resources'),
   }
-
-  #anonymous = this.#project.createDirectory('anonymous');
-  #alias = this.#project.createDirectory('aliases');
-  #models = this.#project.createDirectory('models');
-  #enums = this.#project.createDirectory('enums');
-  #operations = this.#project.createDirectory('operations');
-  #resources = this.#project.createDirectory('resources');
-
+  
   privateData = new Map<string,any>();
 
   get project() {
@@ -68,16 +61,8 @@ export class ApiModel {
 
   http: HttpProtocol = new HttpProtocol();
 
-
   constructor() {
     (<any>this.#project).api = this;
-  }
-
-  track(targetMap: TargetMap, sourceMap: SourceMap) {
-    // temporary -- use up everything that we are given in the source map.
-    for (const each of values(sourceMap)) {
-      use(each);
-    }
   }
 
   versionInfo = new Array<VersionInfo>();
@@ -157,7 +142,7 @@ export class ApiModel {
   }
 
   isFileAnonymous(sourceFile: SourceFile): boolean {
-    return this.#anonymous.isAncestorOf(sourceFile);
+    return this.#folders.anonymous.isAncestorOf(sourceFile);
   }
 
   getNameAndFile(identity: Identity, type: keyof Folders) {

--- a/adl/core/model/api-model.ts
+++ b/adl/core/model/api-model.ts
@@ -1,6 +1,6 @@
 import { exists, isFile, mkdir, rmdir, writeFile } from '@azure-tools/async-io';
 import { Dictionary, values } from '@azure-tools/linq';
-import { isAnonymous, isProxy, Path, SourceMap, TargetMap, use, valueOf } from '@azure-tools/sourcemap';
+import { isAnonymous, Path, SourceMap, TargetMap, use, valueOf } from '@azure-tools/sourcemap';
 import { dirname, join } from 'path';
 import { EnumDeclaration, IndentationText, NewLineKind, Node, Project, QuoteKind, SourceFile } from 'ts-morph';
 import { getNode, referenceTo } from '../support/typescript';
@@ -50,9 +50,6 @@ export class ApiModel {
     return this.#project;
   }
   getPrivateData(path: Path): Dictionary<any> {
-    if (isProxy(this)) {
-      return valueOf(this).getPrivateData(path);
-    }
     const p = path.join('/');
     let v = this.privateData.get(p);
     if( !v ) {
@@ -138,9 +135,6 @@ export class ApiModel {
   }
 
   getFile(identity: Identity, type: keyof Folders ): SourceFile {
-    if (isProxy(this)) {
-      return valueOf(this).getFile(identity, type);
-    }
     if (isAnonymous(identity) ) {
       identity = identity.name;
       type = 'anonymous';
@@ -163,9 +157,6 @@ export class ApiModel {
   }
 
   isFileAnonymous(sourceFile: SourceFile): boolean {
-    if (isProxy(this)) {
-      return valueOf(this).isFileAnonymous(sourceFile);
-    }
     return this.#anonymous.isAncestorOf(sourceFile);
   }
 
@@ -185,7 +176,7 @@ export class ApiModel {
    */
   getTypeReference(schema: Schema, targetSourceFile: SourceFile): string {
     schema = valueOf(schema);
-    
+
     // get all the imports required for the type 
     // add them to this file
     const importDecls = targetSourceFile.getImportDeclarations();

--- a/adl/core/model/element.ts
+++ b/adl/core/model/element.ts
@@ -29,7 +29,7 @@ export class Initializer {
       
 
       if (value !== undefined) {
-        const rawValue = (<any>value).valueOf();
+        const rawValue = (<any>value);
         
         const targetProperty = proxy[key];
         if (targetProperty && targetProperty.push ) {
@@ -68,7 +68,7 @@ export class Element extends Initializer {
     use(value, true);
     if (value) {
       this.attic = this.attic || {};
-      this.attic[name] = value.valueOf();
+      this.attic[name] = value;
     }
     return this;
   }
@@ -113,7 +113,7 @@ export class TSElement<TNode extends Node> extends Initializer implements Elemen
   addToAttic(name: string, value: any): this {
     use(value, true);
     if (value) {
-      this.attic[name] = value.valueOf();
+      this.attic[name] = value;
     }
     return this;
   }

--- a/adl/core/model/element.ts
+++ b/adl/core/model/element.ts
@@ -1,5 +1,4 @@
 import { Dictionary, items } from '@azure-tools/linq';
-import { TrackedTarget, use } from '@azure-tools/sourcemap';
 import { Node } from 'ts-morph';
 import { setTag } from '../support/doc-tag';
 import { getPath, project } from '../support/typescript';
@@ -16,34 +15,28 @@ export class Initializer {
   initialize<T>(initializer?: Partial<T>) {
     const isBackedByTS = 'node' in this;
 
-    if (isBackedByTS) {
-      // autotrack
-      (<any>this).track(initializer);
-    }
-
     for (const [key, value] of items(initializer)) {
       // copy the true value of the items to the object
       // (use the proxy)
         
-      const proxy = isBackedByTS ? <any>this : (<any>TrackedTarget.track(this));
-      
+      const rawThis = <any>this;
 
       if (value !== undefined) {
         const rawValue = (<any>value);
         
-        const targetProperty = proxy[key];
+        const targetProperty = rawThis[key];
         if (targetProperty && targetProperty.push ) {
           if (rawValue[Symbol.iterator]) {
             // copy elements to target
             for (const each of rawValue) {
-              proxy[key].push(each);
+              rawThis[key].push(each);
             }
             continue;
           }
           throw new Error(`Initializer for object with array member '${key}', must be initialized with something that can be iterated.`);
         }
         // just copy the value across.
-        proxy[key] = (<any>value);
+        rawThis[key] = (<any>value);
       }
     }
     return this;
@@ -65,7 +58,6 @@ export class Element extends Initializer {
   }
 
   addToAttic(name: string, value: any) {
-    use(value, true);
     if (value) {
       this.attic = this.attic || {};
       this.attic[name] = value;
@@ -111,7 +103,6 @@ export class TSElement<TNode extends Node> extends Initializer implements Elemen
   }
 
   addToAttic(name: string, value: any): this {
-    use(value, true);
     if (value) {
       this.attic[name] = value;
     }
@@ -129,27 +120,6 @@ export class TSElement<TNode extends Node> extends Initializer implements Elemen
     if (info.deprecated ) {
       setTag(this.node, 'deprecated', info.deprecated);
     }
-  }
-
-
-  /**
-   * targetMap is a function that gives back a dictionary of members to Path (how to find the member in the ts project)
-   * @param childMap a childmap that should be copied on top of any defintions that this class has
-   * 
-   * @notes - every child class of this class should override {@link targetMap}
-   */
-  get targetMap(): Dictionary<any> {
-    return {
-    };
-  }
-
-  /**
-   * 
-   * @param sourceMap 
-   */
-  track(sourceMap: Dictionary<any>) {
-    this.project.track(this.targetMap, sourceMap);
-    return this;
   }
 
 

--- a/adl/core/model/schema/enum.ts
+++ b/adl/core/model/schema/enum.ts
@@ -1,5 +1,5 @@
 import { Dictionary } from '@azure-tools/linq';
-import { isAnonymous, valueOf } from '@azure-tools/sourcemap';
+import { isAnonymous } from '@azure-tools/sourcemap';
 import { EnumDeclaration, EnumMember } from 'ts-morph';
 import { literal, normalizeIdentifier } from '../../support/codegen';
 import { appendTag, getFirstDoc, hasTag, setTag } from '../../support/doc-tag';
@@ -45,7 +45,7 @@ class EnumValueImpl extends TSElement<EnumMember> implements EnumValue {
     return getFirstDoc(this.node).getDescription();
   }
   set description(value: string | undefined) {
-    getFirstDoc(this.node).setDescription(valueOf(value) || '\n');
+    getFirstDoc(this.node).setDescription(value || '\n');
   }
 }
 
@@ -77,8 +77,8 @@ class EnumImpl extends TSSchema<EnumDeclaration> implements Enum {
   readonly values: Collection<EnumValue>;
 
   private addValue(value: EnumValue) {
-    const name = valueOf(value.name) ?? value.value.toString();
-    let val = valueOf(value.value);
+    const name = value.name ?? value.value.toString();
+    let val = value.value;
     
     if (typeof val !== 'string' && typeof val !== 'number') {
       // TODO: how would we represent enum of non-string, non-number?
@@ -99,7 +99,7 @@ class EnumImpl extends TSSchema<EnumDeclaration> implements Enum {
   }
 
   private removeValue(value: EnumValue) {
-    const name = valueOf(value.name) ?? value.value.toString();
+    const name = value.name ?? value.value.toString();
     this.node.getMember(name)?.remove();
   }
 

--- a/adl/core/model/schema/enum.ts
+++ b/adl/core/model/schema/enum.ts
@@ -1,9 +1,7 @@
-import { Dictionary } from '@azure-tools/linq';
 import { isAnonymous } from '@azure-tools/sourcemap';
 import { EnumDeclaration, EnumMember } from 'ts-morph';
 import { literal, normalizeIdentifier } from '../../support/codegen';
 import { appendTag, getFirstDoc, hasTag, setTag } from '../../support/doc-tag';
-import { getPath } from '../../support/typescript';
 import { ApiModel } from '../api-model';
 import { TSElement } from '../element';
 import { Collection, CollectionImpl, Identity } from '../types';
@@ -21,14 +19,6 @@ export interface EnumValue {
 }
 
 class EnumValueImpl extends TSElement<EnumMember> implements EnumValue {
-  get targetMap() {
-    return {
-      ...super.targetMap,
-      $: getPath(this.node),
-      value: getPath(this.node, 'getValue')
-    };
-  }
-
   constructor(node: EnumMember) {
     super(node);
   }
@@ -50,13 +40,6 @@ class EnumValueImpl extends TSElement<EnumMember> implements EnumValue {
 }
 
 class EnumImpl extends TSSchema<EnumDeclaration> implements Enum {
-  get targetMap(): Dictionary<any> {
-    return {
-      ...super.targetMap,
-      $: getPath(this.node),
-    };
-  }
-
   get extensible() {
     return hasTag(this.node, 'extensible');
   }
@@ -91,10 +74,7 @@ class EnumImpl extends TSSchema<EnumDeclaration> implements Enum {
     });
     const result = new EnumValueImpl(member);
     result.description = value.description;
-    result.track({
-      $: name,
-      value: val
-    });
+    
     return result;
   }
 
@@ -146,9 +126,6 @@ export function createEnum(api: ApiModel, identity: Identity, values: Array<Enum
   }
 
   result.initialize(initializer);
-  result.track({
-    $: name
-  });
-
+ 
   return result;
 }

--- a/adl/core/model/schema/object.ts
+++ b/adl/core/model/schema/object.ts
@@ -1,8 +1,7 @@
-import { TargetMap } from '@azure-tools/sourcemap';
 import { InterfaceDeclaration, PropertySignature } from 'ts-morph';
 import { normalizeIdentifier } from '../../support/codegen';
 import { getTagValue, setTag } from '../../support/doc-tag';
-import { getPath, TypeDeclaration } from '../../support/typescript';
+import { TypeDeclaration } from '../../support/typescript';
 import { ApiModel } from '../api-model';
 import { Collection, CollectionImpl, Identity } from '../types';
 import { NamedElement, Schema, TSSchema } from './schema';
@@ -32,13 +31,6 @@ export interface PropInitializer extends Partial<Property> {
 }
 
 export class ObjectSchemaImpl extends TSSchema<InterfaceDeclaration> implements ObjectSchema {
-  get targetMap(): TargetMap {
-    return {
-      ...super.targetMap,
-      $: getPath(this.node)
-    };
-  }
-
   addParent(...parents: Array<TSSchema<TypeDeclaration>> ) {
     // ensure we have an import to the type
     // and add it to the list
@@ -97,11 +89,6 @@ export class ObjectSchemaImpl extends TSSchema<InterfaceDeclaration> implements 
 
     result.initialize(initializer);
 
-    result.track({
-      $: name,
-      type: schema,
-    });
-
     return result;
   }
 
@@ -124,10 +111,6 @@ export function createObjectSchema(api: ApiModel, identity: Identity, initialize
   }));
 
   result.initialize(initializer);
-  
-  result.track( {
-    $: identity, 
-  });
 
   return result;
 }

--- a/adl/core/model/schema/primitive.ts
+++ b/adl/core/model/schema/primitive.ts
@@ -1,4 +1,3 @@
-import { valueOf } from '@azure-tools/sourcemap';
 import { TypeDeclaration } from '../../support/typescript';
 import { Schema, TSSchema } from './schema';
 
@@ -12,7 +11,7 @@ export class Primitive extends Schema {
   }
 
   get typeDefinition(): string {
-    return <string>valueOf(this.kind);
+    return <string>this.kind;
   }
 }
 

--- a/adl/core/model/schema/schema.ts
+++ b/adl/core/model/schema/schema.ts
@@ -1,8 +1,7 @@
-import { Dictionary } from '@azure-tools/linq';
 import { anonymous, isAnonymous } from '@azure-tools/sourcemap';
 import { Node } from 'ts-morph';
 import { getFirstDoc, getTagValue, setTag } from '../../support/doc-tag';
-import { getPath, IsTypeDeclaration, TypeDeclaration } from '../../support/typescript';
+import { IsTypeDeclaration, TypeDeclaration } from '../../support/typescript';
 import { Element, TSElement } from '../element';
 import { Identity } from '../types';
 
@@ -69,14 +68,6 @@ export class Schema extends Element {
 }
 
 export class NamedElement<TNode extends Node> extends TSElement<TNode> {
-  get targetMap(): Dictionary<any> {
-    return {
-      ...super.targetMap,
-      summary: getPath(this.node, /* path to summary jsdoc */),
-      description: getPath(this.node, /* path to description jsdoc */),
-    };
-  }
-
   get name(): Identity {
     let result: Identity | undefined = undefined;
     if (Node.isNamedNode(this.node) || Node.isNameableNode(this.node)) {

--- a/adl/core/model/schema/schema.ts
+++ b/adl/core/model/schema/schema.ts
@@ -1,5 +1,5 @@
 import { Dictionary } from '@azure-tools/linq';
-import { anonymous, isAnonymous, valueOf } from '@azure-tools/sourcemap';
+import { anonymous, isAnonymous } from '@azure-tools/sourcemap';
 import { Node } from 'ts-morph';
 import { getFirstDoc, getTagValue, setTag } from '../../support/doc-tag';
 import { getPath, IsTypeDeclaration, TypeDeclaration } from '../../support/typescript';
@@ -56,7 +56,7 @@ export class Schema extends Element {
    * return the defintion as it would be used. 
    */
   get typeDefinition(): string {
-    return `unknown /*= (not tsschema -- ${Object.getPrototypeOf(this).name}${valueOf(this.name)}/${(<any>this).kind} ) =*/`;
+    return `unknown /*= (not tsschema -- ${Object.getPrototypeOf(this).name}${this.name}/${(<any>this).kind} ) =*/`;
   }
 
   /**
@@ -92,21 +92,21 @@ export class NamedElement<TNode extends Node> extends TSElement<TNode> {
     if (!Node.isRenameableNode(this.node)) {
       throw new Error('This node cannot be renamed.');
     }
-    this.node.rename(valueOf(value));
+    this.node.rename(value);
   }
 
   get summary() {
     return getFirstDoc(this.node).getDescription();
   }
   set summary(value: string | undefined) {
-    getFirstDoc(this.node).setDescription(valueOf(value)||'\n');
+    getFirstDoc(this.node).setDescription(value||'\n');
   }
 
   get description() {
     return getTagValue(this.node, 'description');
   }
   set description(value: string | undefined) {
-    setTag(this.node,'description', valueOf(value));
+    setTag(this.node,'description', value);
   }
 }
 

--- a/adl/core/serialization/openapi/common.ts
+++ b/adl/core/serialization/openapi/common.ts
@@ -78,7 +78,7 @@ export function isEnumSchema(schema: v3.Schema | v2.Schema) {
 
 export function addExtensionsToAttic<T extends Element>(element: T, input: any) {
   for (const [ key, value] of vendorExtensions(input)) {
-    element.addToAttic(key, value, true);
+    element.addToAttic(key, value);
   }
   return element;
 }

--- a/adl/core/serialization/openapi/common.ts
+++ b/adl/core/serialization/openapi/common.ts
@@ -1,6 +1,6 @@
 import { length } from '@azure-tools/linq';
 import { common, StringFormat, v2, v3, vendorExtensions } from '@azure-tools/openapi';
-import { use, valueOf } from '@azure-tools/sourcemap';
+import { use } from '@azure-tools/sourcemap';
 import { Element } from '../../model/element';
 
 export async function toArray<T>(g: AsyncGenerator<T>) {
@@ -55,7 +55,7 @@ export function isObjectSchema(schema: v3.Schema| v2.Schema) {
 }
 
 export function isPrimitiveSchema(schema: v3.Schema | v2.Schema) {
-  switch (valueOf(schema.type)) {
+  switch (schema.type) {
     case common.JsonType.String:
       // file format generally means a blob body
       if (schema.format == StringFormat.File) {

--- a/adl/core/serialization/openapi/common.ts
+++ b/adl/core/serialization/openapi/common.ts
@@ -1,6 +1,5 @@
 import { length } from '@azure-tools/linq';
 import { common, StringFormat, v2, v3, vendorExtensions } from '@azure-tools/openapi';
-import { use } from '@azure-tools/sourcemap';
 import { Element } from '../../model/element';
 
 export async function toArray<T>(g: AsyncGenerator<T>) {
@@ -79,7 +78,7 @@ export function isEnumSchema(schema: v3.Schema | v2.Schema) {
 
 export function addExtensionsToAttic<T extends Element>(element: T, input: any) {
   for (const [ key, value] of vendorExtensions(input)) {
-    element.addToAttic(key, use(value, true));
+    element.addToAttic(key, value, true);
   }
   return element;
 }

--- a/adl/core/serialization/openapi/common/info.ts
+++ b/adl/core/serialization/openapi/common/info.ts
@@ -1,5 +1,4 @@
 import { common } from '@azure-tools/openapi';
-import { use } from '@azure-tools/sourcemap';
 import { Contact, ContactRole } from '../../../model/contact';
 import { License } from '../../../model/license';
 import { Metadata } from '../../../model/metadata';
@@ -57,9 +56,6 @@ export async function *processInfo<TModel extends OAIModel>(info: common.Info, $
   // add remaining extensions to attic. 
   await addExtensionsToAttic(metadata, info);
 
-  // we handled version much earler.
-  use(info.version);
-
   yield metadata;
 }
 
@@ -84,7 +80,6 @@ export async function *processTag<TModel extends OAIModel>(tag: common.Tag, $: C
     location: tag.externalDocs ? tag.externalDocs.url : undefined,
     description: tag.externalDocs ? tag.externalDocs.description : undefined,
   });
-  use(tag.externalDocs);
 
   await addExtensionsToAttic(reference, tag);
 

--- a/adl/core/serialization/openapi/common/info.ts
+++ b/adl/core/serialization/openapi/common/info.ts
@@ -3,7 +3,7 @@ import { Contact, ContactRole } from '../../../model/contact';
 import { License } from '../../../model/license';
 import { Metadata } from '../../../model/metadata';
 import { Reference } from '../../../model/reference';
-import { Context, is, OAIModel } from '../../../support/visitor';
+import { Context, OAIModel } from '../../../support/visitor';
 import { addExtensionsToAttic } from '../common';
 
 async function *processContact<TModel extends OAIModel>(contact: common.Contact, $: Context<TModel>) {
@@ -38,7 +38,7 @@ export async function *processInfo<TModel extends OAIModel>(info: common.Info, $
   });
 
   // add the author contact
-  if (is(info.contact)) {
+  if (info.contact !== undefined) {
     for await (const c of $.process(processContact, info.contact)) {
       metadata.contacts.push(c)  ;
     }
@@ -46,7 +46,7 @@ export async function *processInfo<TModel extends OAIModel>(info: common.Info, $
   }
 
   // add license
-  if (is(info.license)) {
+  if (info.license !== undefined) {
     for await (const l of $.process(processLicense, info.license) ) {
       metadata.licenses.push(l);
     }

--- a/adl/core/serialization/openapi/common/schema.ts
+++ b/adl/core/serialization/openapi/common/schema.ts
@@ -1,5 +1,5 @@
 import { v2, v3, XMSEnumValue } from '@azure-tools/openapi';
-import { anonymous, nameOf, use } from '@azure-tools/sourcemap';
+import { anonymous, nameOf } from '@azure-tools/sourcemap';
 import { createAlias } from '../../../model/schema/alias';
 import { NullableModifier, ReadOnlyModifier } from '../../../model/schema/constraint';
 import { ServerDefaultValue } from '../../../model/schema/default';
@@ -158,11 +158,11 @@ export async function* processAnySchema<T extends OAIModel>(schema: v3.Schema|v2
 }
 
 export async function* processEnumSchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>, options?: Options): AsyncGenerator<Schema> {
-  const schemaEnum = use(schema.enum, true) ?? [];
-  const xmsEnum = use(schema['x-ms-enum']) ?? {};
-  const values: Array<XMSEnumValue> = use(xmsEnum.values, true) ?? schemaEnum.map(value => ({ value }));
-  const name = use(xmsEnum.name) ?? (options?.isAnonymous ? anonymous('enum') : nameOf(schema));
-  const extensible = use(xmsEnum.modelAsString);
+  const schemaEnum = schema.enum || [];
+  const xmsEnum = schema['x-ms-enum'] || {};
+  const values: Array<XMSEnumValue> = xmsEnum.values|| schemaEnum.map(value => ({ value }));
+  const name = xmsEnum.name || (options?.isAnonymous ? anonymous('enum') : nameOf(schema));
+  const extensible = xmsEnum.modelAsString;
 
   yield createEnum($.api, name, values, { 
     extensible, 

--- a/adl/core/serialization/openapi/common/schema.ts
+++ b/adl/core/serialization/openapi/common/schema.ts
@@ -93,7 +93,6 @@ export async function* processUriSchema<T extends OAIModel>(schema: v3.Schema|v2
   if ($.forbiddenProperties(schema, ...<any>notPrimitiveProperties)) {
     return;
   }
-  use(schema.example);
 
   return yield addAliasWithDefault(schema, $.api.schemas.Uri, $);
 }
@@ -136,7 +135,6 @@ export function addAliasWithDefault<T extends OAIModel>(schema: v3.Schema | v2.S
     if (schema.default) {
       alias.defaults.push(new ServerDefaultValue(schema.default));
     }
-    use(schema.default, true);
 
     if ((<any>schema).readOnly) {
       alias.constraints.push(new ReadOnlyModifier());

--- a/adl/core/serialization/openapi/v2/body-parameter.ts
+++ b/adl/core/serialization/openapi/v2/body-parameter.ts
@@ -1,6 +1,6 @@
 import { values } from '@azure-tools/linq';
 import { v2 } from '@azure-tools/openapi';
-import { anonymous, nameOf, use } from '@azure-tools/sourcemap';
+import { anonymous, nameOf } from '@azure-tools/sourcemap';
 import { Request } from '../../../model/http/request';
 import { singleOrDefault } from '../common';
 import { processInline } from './schema';
@@ -14,8 +14,6 @@ export async function* requestBody(body: v2.BodyParameter, $: Context, options?:
   const operation = options?.operation;
   const consumes = operation?.consumes || $.sourceModel.consumes || [];
 
-  use(body.in);
-  
   for (const mediaType of values(consumes)) {
     const schema = await singleOrDefault(processInline(<v2.Schema>body.schema, $)) || $.api.schemas.Any;
     const request = new Request(bodyName, mediaType, schema, {

--- a/adl/core/serialization/openapi/v2/parameter.ts
+++ b/adl/core/serialization/openapi/v2/parameter.ts
@@ -1,5 +1,4 @@
 import { v2 } from '@azure-tools/openapi';
-import { use } from '@azure-tools/sourcemap';
 import { FormDataParameter, HeaderParameter, PathParameter, QueryParameter, RenderStyle } from '../../../model/http/parameter';
 import { singleOrDefault } from '../common';
 import { processInline } from './schema';
@@ -7,7 +6,7 @@ import { Context } from './serializer';
 
 export async function* parameter(parameter: v2.Parameter, $: Context, options?: { isAnonymous?: boolean }) {
 
-  switch (use(parameter.in)) {
+  switch (parameter.in) {
     case v2.ParameterLocation.Path:
       return yield* processPathParameter(<v2.PathParameter>parameter, $, options);
 

--- a/adl/core/serialization/openapi/v2/parameter.ts
+++ b/adl/core/serialization/openapi/v2/parameter.ts
@@ -1,5 +1,5 @@
 import { v2 } from '@azure-tools/openapi';
-import { use, valueOf } from '@azure-tools/sourcemap';
+import { use } from '@azure-tools/sourcemap';
 import { FormDataParameter, HeaderParameter, PathParameter, QueryParameter, RenderStyle } from '../../../model/http/parameter';
 import { singleOrDefault } from '../common';
 import { processInline } from './schema';
@@ -7,7 +7,7 @@ import { Context } from './serializer';
 
 export async function* parameter(parameter: v2.Parameter, $: Context, options?: { isAnonymous?: boolean }) {
 
-  switch (valueOf(use(parameter.in))) {
+  switch (use(parameter.in)) {
     case v2.ParameterLocation.Path:
       return yield* processPathParameter(<v2.PathParameter>parameter, $, options);
 

--- a/adl/core/serialization/openapi/v2/schema.ts
+++ b/adl/core/serialization/openapi/v2/schema.ts
@@ -455,15 +455,6 @@ export async function* processObjectSchema(schema: v2.Schema, $: Context, option
     // result.properties.push(p);
     //result.properties.add(p);
   }
-  
-  /*
-  if (!isUsed(schema.required)) {
-    for (const each of unusedMembers(schema.required)) {
-      $.error(`Schema '${nameOf(schema)}' has required for property named '${(<any>schema.required)[each]}' `, schema);
-    }
-    throw new Error('fatal error');
-  }
-  */
 
   if (schema.additionalProperties) {
     // if additionalProperties is specified, then the type should

--- a/adl/core/serialization/openapi/v2/schema.ts
+++ b/adl/core/serialization/openapi/v2/schema.ts
@@ -1,6 +1,6 @@
 import { items, length, values } from '@azure-tools/linq';
 import { IntegerFormat, NumberFormat, StringFormat, v2 } from '@azure-tools/openapi';
-import { anonymous, nameOf, use, using } from '@azure-tools/sourcemap';
+import { anonymous, nameOf, using } from '@azure-tools/sourcemap';
 import { Alias as GenericAlias } from '../../../model/alias';
 import { createAlias } from '../../../model/schema/alias';
 import { ExclusiveMaximumConstraint, ExclusiveMinimumConstraint, MaximumConstraint, MaximumElementsConstraint, MaximumPropertiesConstraint, MaxLengthConstraint, MinimumConstraint, MinimumElementsConstraint, MinimumPropertiesConstraint, MinLengthConstraint, MultipleOfConstraint, ReadOnlyModifier, RegularExpressionConstraint, UniqueElementsConstraint } from '../../../model/schema/constraint';
@@ -29,7 +29,7 @@ export async function* processInline(schema: v2.Schema | v2.SchemaReference | un
 }
 
 async function* getSchemas(schemas: Array<v2.Schema | v2.SchemaReference> | undefined, $: Context): AsyncGenerator<Schema> {
-  for (const each of values(use(schemas))) {
+  for (const each of values(schemas)) {
     for await (const schema of $.processInline(processSchema, each, { isAnonymous: true })) {
       yield schema instanceof GenericAlias ? schema.target : schema;
     }
@@ -43,9 +43,7 @@ export async function* processSillyRef(schema: v2.Schema, $: Context, options?: 
 }
 
 export async function* processSchema(schema: v2.Schema, $: Context, options?: { isAnonymous?: boolean }): AsyncGenerator<Schema> {
-  // mark this used once.
-  use(schema.type);
-
+  
   const impl = () => {
     // if enum or x-ms-enum is specified, process as enum
     if (isEnumSchema(schema)) {
@@ -67,7 +65,7 @@ export async function* processSchema(schema: v2.Schema, $: Context, options?: { 
       return processObjectSchema(schema, $, options);
     }
 
-    switch (schema.type?.valueOf()) {
+    switch (schema.type) {
       case v2.JsonType.String:
         return processStringSchema(schema, $);
 
@@ -93,7 +91,7 @@ export async function* processSchema(schema: v2.Schema, $: Context, options?: { 
         // dig deeper to figure out what this should be.
 
         // first, let's see if we can tell by format:
-        switch (schema.format?.valueOf()) {
+        switch (schema.format) {
           // is it some kind of binary response?
           case StringFormat.Binary:
           case StringFormat.File:
@@ -126,7 +124,6 @@ export async function* processSchema(schema: v2.Schema, $: Context, options?: { 
   };
   for await (const result of impl()) {
     if (result && schema.example) {
-      use(schema.example, true);
       result.addToAttic('example', schema.example);
     }
     yield result;
@@ -134,8 +131,7 @@ export async function* processSchema(schema: v2.Schema, $: Context, options?: { 
 }
 
 export async function* processStringSchema(schema: v2.Schema, $: Context): AsyncGenerator<Schema> {
-  use(schema.format);
-  switch (schema.format?.valueOf()) {
+  switch (schema.format) {
     case StringFormat.Base64Url:
     case StringFormat.Byte:
     case StringFormat.Binary:
@@ -217,11 +213,9 @@ export async function* processIntegerSchema(schema: v2.Schema, $: Context): Asyn
     return;
   }
 
-  const format = use(schema.format);
-
   let result: Schema;
 
-  switch (format?.valueOf()) {
+  switch (schema.format) {
     case IntegerFormat.Int32:
       result = $.api.schemas.Int32;
       break;
@@ -237,14 +231,13 @@ export async function* processIntegerSchema(schema: v2.Schema, $: Context): Asyn
 
 
     default:
-      throw new Error(`Unexpected integer format: ${format}`);
+      throw new Error(`Unexpected integer format: ${schema.format}`);
   }
 
   yield constrainNumericSchema(schema, $, result);
 }
 
 export async function* processNumberSchema(schema: v2.Schema, $: Context): AsyncGenerator<Schema> {
-  const format = use(schema.format);
 
   if ($.forbiddenProperties(schema, ...stringProperties, ...objectProperties, ...arrayProperties)) {
     return;
@@ -252,7 +245,7 @@ export async function* processNumberSchema(schema: v2.Schema, $: Context): Async
 
   let result: Schema;
 
-  switch (format?.valueOf()) {
+  switch (schema.format) {
     case NumberFormat.Float:
       result = $.api.schemas.Float;
       break;
@@ -263,7 +256,7 @@ export async function* processNumberSchema(schema: v2.Schema, $: Context): Async
       break;
 
     default:
-      throw new Error(`Unexpected number format: ${format}`);
+      throw new Error(`Unexpected number format: ${schema.format}`);
   }
 
   yield constrainNumericSchema(schema, $, result);
@@ -332,7 +325,6 @@ export async function* processArraySchema(schema: v2.Schema, $: Context, options
 
   if (schema.default) {
     alias.defaults.push(new ServerDefaultValue(schema.default));
-    use(schema.default, true); // default can be more than a primitive value
   }
 
   if (schema.readOnly) {
@@ -436,7 +428,7 @@ export async function* processObjectSchema(schema: v2.Schema, $: Context, option
   yield result;
 
   // process the properties
-  for (const [propertyName, property] of items(use(schema.properties))) {
+  for (const [propertyName, property] of items(schema.properties)) {
     // process schema/reference inline
     const propSchema = await singleOrDefault(processInline(property, $, { isAnonymous: true })) || $.api.schemas.Any;
 
@@ -463,8 +455,7 @@ export async function* processObjectSchema(schema: v2.Schema, $: Context, option
     // result.properties.push(p);
     //result.properties.add(p);
   }
-  use(schema.required);
-
+  
   /*
   if (!isUsed(schema.required)) {
     for (const each of unusedMembers(schema.required)) {

--- a/adl/core/serialization/openapi/v2/security.ts
+++ b/adl/core/serialization/openapi/v2/security.ts
@@ -27,7 +27,7 @@ export async function* authenticationRequirement(securityRequirement: v2.Securit
 }
 
 export async function* authentication(scheme: v2.SecurityScheme, $: Context) {
-  switch (scheme.type) {
+  switch ((<any>scheme).type) {
     case 'apiKey':
       return yield *apiKeyAuthentication(<v2.ApiKeySecurityScheme>scheme, $);
     case 'basic':

--- a/adl/core/serialization/openapi/v2/security.ts
+++ b/adl/core/serialization/openapi/v2/security.ts
@@ -1,6 +1,6 @@
 import { items } from '@azure-tools/linq';
 import { JsonReference, v2 } from '@azure-tools/openapi';
-import { getSourceFile, nameOf, use } from '@azure-tools/sourcemap';
+import { getSourceFile, nameOf } from '@azure-tools/sourcemap';
 import { ApiKeyAuthentication, AuthenticationReference, AuthenticationRequirement, AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, HttpAuthentication, ImplicitOAuth2Flow, OAuth2Authentication, OAuth2Flow, OAuth2Flows, OAuth2Scope, ParameterLocation, PasswordOAuth2Flow } from '../../../model/http/protocol';
 import { addExtensionsToAttic, single } from '../common';
 import { Context } from './serializer';
@@ -16,8 +16,8 @@ export async function* authenticationRequirement(securityRequirement: v2.Securit
 
     const auth = await single($.processInline(authentication, ref));
     const authRef = new AuthenticationReference(auth);
-    for (const scope of use(scopes)) {
-      authRef.scopes.push(use(scope));
+    for (const scope of scopes) {
+      authRef.scopes.push(scope);
     }
 
     result.authentications.push(authRef);
@@ -27,7 +27,7 @@ export async function* authenticationRequirement(securityRequirement: v2.Securit
 }
 
 export async function* authentication(scheme: v2.SecurityScheme, $: Context) {
-  switch (use(scheme.type)) {
+  switch (scheme.type) {
     case 'apiKey':
       return yield *apiKeyAuthentication(<v2.ApiKeySecurityScheme>scheme, $);
     case 'basic':
@@ -42,7 +42,7 @@ export async function* authentication(scheme: v2.SecurityScheme, $: Context) {
 function *apiKeyAuthentication(scheme: v2.ApiKeySecurityScheme, $: Context) {
   let location: ParameterLocation;
 
-  switch (use(scheme.in)) {
+  switch (scheme.in) {
     case 'header':
       location = ParameterLocation.Header;
       break;
@@ -69,7 +69,7 @@ function *oauth2Authentication(scheme: v2.OAuthSecurityBase, $: Context) {
   let flow: OAuth2Flow;
   const flows = new OAuth2Flows();
 
-  switch (use(scheme.flow)) {
+  switch (scheme.flow) {
     case 'password': {
       const password = <v2.OAuth2PasswordSecurityScheme>scheme;
       flow = flows.password = new PasswordOAuth2Flow(password.tokenUrl);
@@ -95,7 +95,7 @@ function *oauth2Authentication(scheme: v2.OAuthSecurityBase, $: Context) {
       return;
   }
 
-  for (const [ name, description] of items(use(scheme.scopes))) {
+  for (const [ name, description] of items(scheme.scopes)) {
     flow.scopes.push(new OAuth2Scope(name, description));
   }
 

--- a/adl/core/serialization/openapi/v2/security.ts
+++ b/adl/core/serialization/openapi/v2/security.ts
@@ -1,6 +1,6 @@
 import { items } from '@azure-tools/linq';
 import { JsonReference, v2 } from '@azure-tools/openapi';
-import { getSourceFile, nameOf, use, valueOf } from '@azure-tools/sourcemap';
+import { getSourceFile, nameOf, use } from '@azure-tools/sourcemap';
 import { ApiKeyAuthentication, AuthenticationReference, AuthenticationRequirement, AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, HttpAuthentication, ImplicitOAuth2Flow, OAuth2Authentication, OAuth2Flow, OAuth2Flows, OAuth2Scope, ParameterLocation, PasswordOAuth2Flow } from '../../../model/http/protocol';
 import { addExtensionsToAttic, single } from '../common';
 import { Context } from './serializer';
@@ -27,7 +27,7 @@ export async function* authenticationRequirement(securityRequirement: v2.Securit
 }
 
 export async function* authentication(scheme: v2.SecurityScheme, $: Context) {
-  switch (valueOf(use(scheme.type))) {
+  switch (use(scheme.type)) {
     case 'apiKey':
       return yield *apiKeyAuthentication(<v2.ApiKeySecurityScheme>scheme, $);
     case 'basic':
@@ -42,7 +42,7 @@ export async function* authentication(scheme: v2.SecurityScheme, $: Context) {
 function *apiKeyAuthentication(scheme: v2.ApiKeySecurityScheme, $: Context) {
   let location: ParameterLocation;
 
-  switch (valueOf(use(scheme.in))) {
+  switch (use(scheme.in)) {
     case 'header':
       location = ParameterLocation.Header;
       break;
@@ -69,7 +69,7 @@ function *oauth2Authentication(scheme: v2.OAuthSecurityBase, $: Context) {
   let flow: OAuth2Flow;
   const flows = new OAuth2Flows();
 
-  switch (valueOf(use(scheme.flow))) {
+  switch (use(scheme.flow)) {
     case 'password': {
       const password = <v2.OAuth2PasswordSecurityScheme>scheme;
       flow = flows.password = new PasswordOAuth2Flow(password.tokenUrl);

--- a/adl/core/serialization/openapi/v2/serializer.ts
+++ b/adl/core/serialization/openapi/v2/serializer.ts
@@ -1,7 +1,6 @@
 import { items } from '@azure-tools/linq';
 import { Dictionary, isReference, JsonReference, v2, vendorExtensions } from '@azure-tools/openapi';
 import { isVendorExtension, ParameterLocation } from '@azure-tools/openapi/dist/v2';
-import { use } from '@azure-tools/sourcemap';
 import { Alias as GenericAlias } from '../../../model/alias';
 import { ApiModel } from '../../../model/api-model';
 import { Alias, createAlias } from '../../../model/schema/alias';
@@ -138,11 +137,6 @@ async function processRoot(oai2: v2.Model, $: Context) {
   for await (const operation of $.processDictionary(path, oai2['x-ms-paths'])) {
     $.api.http.operations.push(operation);
   }
-
-  // we don't need this.
-  use(oai2.swagger);
-  use(oai2.consumes, true);
-  use(oai2.produces, true);
 
   return $.api;
 }

--- a/adl/core/serialization/openapi/v2/serializer.ts
+++ b/adl/core/serialization/openapi/v2/serializer.ts
@@ -106,7 +106,7 @@ async function processRoot(oai2: v2.Model, $: Context) {
       continue;
     }
 
-    throw new Error('Should not get here.');
+    throw new Error(`Should not get here. '${schema.name}' is of type ${Object.getPrototypeOf(schema).name}`);
   }
 
 

--- a/adl/core/serialization/openapi/v2/server.ts
+++ b/adl/core/serialization/openapi/v2/server.ts
@@ -1,11 +1,10 @@
 import { v2 } from '@azure-tools/openapi';
-import { use } from '@azure-tools/sourcemap';
 import { Connection } from '../../../model/http/protocol';
 import { Context } from './serializer';
 
 export async function* processServers(model: v2.Model, $: Context): AsyncGenerator<Connection> {
-  for (const scheme of use(model.schemes) ?? []) {
-    const url = `${use(scheme)}://${use(model.host)}${use(model.basePath) ?? '/'}`;
+  for (const scheme of model.schemes ?? []) {
+    const url = `${scheme}://${model.host}${model.basePath ?? '/'}`;
     yield new Connection(url);
   }
 }

--- a/adl/core/serialization/openapi/v3/header.ts
+++ b/adl/core/serialization/openapi/v3/header.ts
@@ -1,5 +1,5 @@
 import { v3 } from '@azure-tools/openapi';
-import { anonymous, nameOf, refTo, use } from '@azure-tools/sourcemap';
+import { anonymous, nameOf, refTo } from '@azure-tools/sourcemap';
 import { Header } from '../../../model/http/header';
 import { singleOrDefault } from '../common';
 import { processInline } from './schema';
@@ -10,8 +10,8 @@ export async function* header(header: v3.Header, $: Context, options?: { isAnony
   const name = options?.isAnonymous ? anonymous('header') : nameOf(header);
 
   // these are in the OAI schema, but should not be in headers - freakout if they are used
-  use(header.explode) && $.error('header definitions must not contain property \'explode\'', header.explode);
-  use(header.required) && $.warn('header definitions should not contain property \'required\'', header.required);
+  header.explode && $.error('header definitions must not contain property \'explode\'', header.explode);
+  header.required && $.warn('header definitions should not contain property \'required\'', header.required);
 
   // get the schema for the header 
   const schema = await singleOrDefault(processInline(header.schema, $, { isAnonymous: true }));
@@ -25,7 +25,7 @@ export async function* header(header: v3.Header, $: Context, options?: { isAnony
     // set a specific value 
     description: header.description,
     // set the style value
-    style: use(header.style),
+    style: header.style,
   });
 
   // best practice - put this into the $refs collection early 
@@ -34,7 +34,7 @@ export async function* header(header: v3.Header, $: Context, options?: { isAnony
   }
 
   // preserve data that we're not using
-  httpHeader.addToAttic('example', use(header.example));
+  httpHeader.addToAttic('example', header.example);
 
   yield httpHeader;
 }

--- a/adl/core/serialization/openapi/v3/parameter.ts
+++ b/adl/core/serialization/openapi/v3/parameter.ts
@@ -1,5 +1,4 @@
 import { v3 } from '@azure-tools/openapi';
-import { use } from '@azure-tools/sourcemap';
 import { CookieParameter, HeaderParameter, PathParameter, QueryParameter, RenderStyle } from '../../../model/http/parameter';
 import { singleOrDefault } from '../common';
 import { processInline } from './schema';
@@ -7,7 +6,7 @@ import { Context } from './serializer';
 
 export async function* parameter(parameter: v3.Parameter, $: Context, options?: { isAnonymous?: boolean }) {
 
-  switch (use(parameter.in)) {
+  switch (parameter.in) {
     case v3.ParameterLocation.Path:
       return yield* processPathParameter(<v3.PathParameter>parameter, $, options);
 

--- a/adl/core/serialization/openapi/v3/parameter.ts
+++ b/adl/core/serialization/openapi/v3/parameter.ts
@@ -1,5 +1,5 @@
 import { v3 } from '@azure-tools/openapi';
-import { use, valueOf } from '@azure-tools/sourcemap';
+import { use } from '@azure-tools/sourcemap';
 import { CookieParameter, HeaderParameter, PathParameter, QueryParameter, RenderStyle } from '../../../model/http/parameter';
 import { singleOrDefault } from '../common';
 import { processInline } from './schema';
@@ -7,7 +7,7 @@ import { Context } from './serializer';
 
 export async function* parameter(parameter: v3.Parameter, $: Context, options?: { isAnonymous?: boolean }) {
 
-  switch (valueOf(use(parameter.in))) {
+  switch (use(parameter.in)) {
     case v3.ParameterLocation.Path:
       return yield* processPathParameter(<v3.PathParameter>parameter, $, options);
 

--- a/adl/core/serialization/openapi/v3/schema.ts
+++ b/adl/core/serialization/openapi/v3/schema.ts
@@ -1,6 +1,6 @@
 import { items, length, values } from '@azure-tools/linq';
 import { IntegerFormat, NumberFormat, StringFormat, v3 } from '@azure-tools/openapi';
-import { anonymous, nameOf, use, using } from '@azure-tools/sourcemap';
+import { anonymous, nameOf, using } from '@azure-tools/sourcemap';
 import { Alias as GenericAlias } from '../../../model/alias';
 import { createAlias } from '../../../model/schema/alias';
 import { ExclusiveMaximumConstraint, ExclusiveMinimumConstraint, MaximumConstraint, MaximumElementsConstraint, MaximumPropertiesConstraint, MaxLengthConstraint, MinimumConstraint, MinimumElementsConstraint, MinimumPropertiesConstraint, MinLengthConstraint, MultipleOfConstraint, RegularExpressionConstraint, UniqueElementsConstraint } from '../../../model/schema/constraint';
@@ -32,7 +32,7 @@ export async function* processInline(schema: v3.Schema | v3.SchemaReference | un
 }
 
 async function* getSchemas(schemas: Array<v3.Schema | v3.SchemaReference> | undefined, $: Context): AsyncGenerator<Schema> {
-  for (const each of values(use(schemas))) {
+  for (const each of values(schemas)) {
     for await (const schema of $.processInline(processSchema, each, { isAnonymous: true })) {
       yield schema instanceof GenericAlias ? schema.target : schema;
     }
@@ -133,7 +133,6 @@ export async function* processSillyRef(schema: v3.Schema, $: Context, options?: 
 
 export async function* processSchema(schema: v3.Schema, $: Context, options?: { isAnonymous?: boolean }): AsyncGenerator<Schema> {
   // mark this used once.
-  use(schema.type);
 
   const impl = () => {
     // if enum or x-ms-enum is specified, process as enum
@@ -168,7 +167,7 @@ export async function* processSchema(schema: v3.Schema, $: Context, options?: { 
       return processObjectSchema(schema, $, options);
     }
 
-    switch (schema.type?.valueOf()) {
+    switch (schema.type) {
       case v3.JsonType.String:
         return processStringSchema(schema, $);
 
@@ -194,7 +193,7 @@ export async function* processSchema(schema: v3.Schema, $: Context, options?: { 
         // dig deeper to figure out what this should be.
 
         // first, let's see if we can tell by format:
-        switch (schema.format?.valueOf()) {
+        switch (schema.format) {
           // is it some kind of binary response?
           case StringFormat.Binary:
           case StringFormat.File:
@@ -227,7 +226,6 @@ export async function* processSchema(schema: v3.Schema, $: Context, options?: { 
   };
   for await (const result of impl()) {
     if (result && schema.example) {
-      use(schema.example, true);
       result.addToAttic('example', schema.example);
     }
     yield result;
@@ -235,8 +233,8 @@ export async function* processSchema(schema: v3.Schema, $: Context, options?: { 
 }
 
 export async function* processStringSchema(schema: v3.Schema, $: Context): AsyncGenerator<Schema> {
-  use(schema.format);
-  switch (schema.format?.valueOf()) {
+  
+  switch (schema.format) {
     case StringFormat.Base64Url:
     case StringFormat.Byte:
     case StringFormat.Binary:
@@ -309,12 +307,11 @@ export async function* processIntegerSchema(schema: v3.Schema, $: Context): Asyn
   if ($.forbiddenProperties(schema, ...<any>stringProperties, ...<any>objectProperties, ...<any>arrayProperties)) {
     return;
   }
-
-  const format = use(schema.format);
+  
 
   let result: Schema;
 
-  switch (format?.valueOf()) {
+  switch (schema.format) {
     case IntegerFormat.Int32:
       result = $.api.schemas.Int32;
       break;
@@ -330,14 +327,14 @@ export async function* processIntegerSchema(schema: v3.Schema, $: Context): Asyn
 
 
     default:
-      throw new Error(`Unexpected integer format: ${format}`);
+      throw new Error(`Unexpected integer format: ${schema.format}`);
   }
 
   yield constrainNumericSchema(schema, $, result);
 }
 
 export async function* processNumberSchema(schema: v3.Schema, $: Context): AsyncGenerator<Schema> {
-  const format = use(schema.format);
+  
 
   if ($.forbiddenProperties(schema, ...<any>stringProperties, ...<any>objectProperties, ...<any>arrayProperties)) {
     return;
@@ -345,7 +342,7 @@ export async function* processNumberSchema(schema: v3.Schema, $: Context): Async
 
   let result: Schema;
 
-  switch (format?.valueOf()) {
+  switch (schema.format) {
     case NumberFormat.Float:
       result = $.api.schemas.Float;
       break;
@@ -356,7 +353,7 @@ export async function* processNumberSchema(schema: v3.Schema, $: Context): Async
       break;
 
     default:
-      throw new Error(`Unexpected number format: ${format}`);
+      throw new Error(`Unexpected number format: ${schema.format}`);
   }
 
   yield constrainNumericSchema(schema, $, result);
@@ -418,9 +415,8 @@ export async function* processArraySchema(schema: v3.Schema, $: Context, options
     ...common
   });
 
-  if (schema.default) {
+  if (schema.default !== undefined) {
     alias.defaults.push(new ServerDefaultValue(schema.default));
-    use(schema.default, true); // default can be more than a primitive value
   }
 
   if (schema.maxItems !== undefined) {
@@ -506,7 +502,7 @@ export async function* processObjectSchema(schema: v3.Schema, $: Context, option
   yield result;
 
   // process the properties
-  for (const [propertyName, property] of items(use(schema.properties))) {
+  for (const [propertyName, property] of items(schema.properties)) {
     // process schema/reference inline
     const propSchema = await singleOrDefault(processInline(property, $, { isAnonymous: true })) || $.api.schemas.Any;
 
@@ -527,8 +523,7 @@ export async function* processObjectSchema(schema: v3.Schema, $: Context, option
     $.addVersionInfo(p, property);
     result.properties.push(p);
   }
-  use(schema.required);
-
+  
   /*
   if (!isUsed(schema.required)) {
     for (const each of unusedMembers(schema.required)) {

--- a/adl/core/serialization/openapi/v3/schema.ts
+++ b/adl/core/serialization/openapi/v3/schema.ts
@@ -523,15 +523,6 @@ export async function* processObjectSchema(schema: v3.Schema, $: Context, option
     $.addVersionInfo(p, property);
     result.properties.push(p);
   }
-  
-  /*
-  if (!isUsed(schema.required)) {
-    for (const each of unusedMembers(schema.required)) {
-      $.error(`Schema '${nameOf(schema)}' has required for property named '${(<any>schema.required)[each]}' `, schema);
-    }
-    throw new Error('fatal error');
-  }
-  */
 
   if (schema.additionalProperties) {
     // if additionalProperties is specified, then the type should

--- a/adl/core/serialization/openapi/v3/schema.ts
+++ b/adl/core/serialization/openapi/v3/schema.ts
@@ -1,6 +1,6 @@
 import { items, length, values } from '@azure-tools/linq';
 import { IntegerFormat, NumberFormat, StringFormat, v3 } from '@azure-tools/openapi';
-import { anonymous, isUsed, nameOf, unusedMembers, use, using } from '@azure-tools/sourcemap';
+import { anonymous, nameOf, use, using } from '@azure-tools/sourcemap';
 import { Alias as GenericAlias } from '../../../model/alias';
 import { createAlias } from '../../../model/schema/alias';
 import { ExclusiveMaximumConstraint, ExclusiveMinimumConstraint, MaximumConstraint, MaximumElementsConstraint, MaximumPropertiesConstraint, MaxLengthConstraint, MinimumConstraint, MinimumElementsConstraint, MinimumPropertiesConstraint, MinLengthConstraint, MultipleOfConstraint, RegularExpressionConstraint, UniqueElementsConstraint } from '../../../model/schema/constraint';
@@ -278,26 +278,26 @@ export async function* processStringSchema(schema: v3.Schema, $: Context): Async
 
   // we're going to treat it as a standard string schema
   // if this is just a plain string with no adornments, just return the common string instance. 
-  if (length(unusedMembers(schema)) === 0) {
+  if (!(schema.default !== undefined || schema.minLength !== undefined || schema.maxLength !== undefined || schema.pattern !== undefined)) {
     return yield $.api.schemas.String;
   }
 
   // otherwise, we have to get the standard string and make an alias for it with the adornments. 
   const alias = createAlias($.api,anonymous('string'), $.api.schemas.String, commonProperties(schema));
 
-  if (schema.default) {
+  if (schema.default !== undefined) {
     alias.defaults.push(new ServerDefaultValue(schema.default));
   }
 
-  if (schema.maxLength) {
+  if (schema.maxLength !== undefined) {
     alias.constraints.push(new MaxLengthConstraint(schema.maxLength));
   }
 
-  if (schema.minLength) {
+  if (schema.minLength !== undefined) {
     alias.constraints.push(new MinLengthConstraint(schema.minLength));
   }
 
-  if (schema.pattern) {
+  if (schema.pattern !== undefined) {
     alias.constraints.push(new RegularExpressionConstraint(schema.pattern));
   }
 
@@ -364,7 +364,7 @@ export async function* processNumberSchema(schema: v3.Schema, $: Context): Async
 
 function constrainNumericSchema(schema: v3.Schema, $: Context, target: Schema): Schema {
   // if this is just a number with no adornments, just return the common instance
-  if (length(unusedMembers(schema)) === 0) {
+  if (!(schema.default !== undefined || schema.exclusiveMaximum !== undefined || schema.exclusiveMinimum !== undefined || schema.minimum !== undefined || schema.maximum !== undefined || schema.multipleOf !== undefined)) {
     return target;
   }
 
@@ -375,19 +375,19 @@ function constrainNumericSchema(schema: v3.Schema, $: Context, target: Schema): 
     alias.defaults.push(new ServerDefaultValue(schema.default));
   }
 
-  if (schema.minimum) {
+  if (schema.minimum !== undefined ) {
     alias.constraints.push(new MinimumConstraint(schema.minimum));
   }
-  if (schema.maximum) {
+  if (schema.maximum !== undefined ) {
     alias.constraints.push(new MaximumConstraint(schema.maximum));
   }
-  if (schema.exclusiveMinimum) {
+  if (schema.exclusiveMinimum !== undefined ) {
     alias.constraints.push(new ExclusiveMinimumConstraint(schema.exclusiveMinimum));
   }
-  if (schema.exclusiveMaximum) {
+  if (schema.exclusiveMaximum !== undefined ) {
     alias.constraints.push(new ExclusiveMaximumConstraint(schema.exclusiveMaximum));
   }
-  if (schema.multipleOf) {
+  if (schema.multipleOf !== undefined ) {
     alias.constraints.push(new MultipleOfConstraint(schema.multipleOf));
   }
 
@@ -409,7 +409,7 @@ export async function* processArraySchema(schema: v3.Schema, $: Context, options
 
   const result = new ArraySchema(elementSchema);
 
-  if (length(unusedMembers(schema)) === 0) {
+  if (!(schema.default !== undefined || schema.maxItems !== undefined || schema.minItems !== undefined || schema.uniqueItems !== undefined )) {
     return yield result;
   }
 
@@ -529,12 +529,14 @@ export async function* processObjectSchema(schema: v3.Schema, $: Context, option
   }
   use(schema.required);
 
+  /*
   if (!isUsed(schema.required)) {
     for (const each of unusedMembers(schema.required)) {
       $.error(`Schema '${nameOf(schema)}' has required for property named '${(<any>schema.required)[each]}' `, schema);
     }
     throw new Error('fatal error');
   }
+  */
 
   if (schema.additionalProperties) {
     // if additionalProperties is specified, then the type should

--- a/adl/core/serialization/openapi/v3/security.ts
+++ b/adl/core/serialization/openapi/v3/security.ts
@@ -27,7 +27,7 @@ export async function* authenticationRequirement(securityRequirement: v3.Securit
 }
 
 export async function* authentication(scheme: v3.SecurityScheme, $: Context): AsyncGenerator<Authentication> {
-  switch (scheme.type) {
+  switch ((<any>scheme).type) {
     case v3.SecurityType.ApiKey:
       return yield *apiKeyAuthentication(<v3.ApiKeySecurityScheme>scheme, $);
 

--- a/adl/core/serialization/openapi/v3/security.ts
+++ b/adl/core/serialization/openapi/v3/security.ts
@@ -1,6 +1,6 @@
 import { items } from '@azure-tools/linq';
 import { JsonReference, v3 } from '@azure-tools/openapi';
-import { getSourceFile, nameOf, use } from '@azure-tools/sourcemap';
+import { getSourceFile, nameOf } from '@azure-tools/sourcemap';
 import { ApiKeyAuthentication, Authentication, AuthenticationReference, AuthenticationRequirement, AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, HttpAuthentication, ImplicitOAuth2Flow, OAuth2Authentication, OAuth2Flow, OAuth2Flows, OAuth2Scope, OpenIdConnectAuthentication, ParameterLocation, PasswordOAuth2Flow } from '../../../model/http/protocol';
 import { addExtensionsToAttic, single } from '../common';
 import { Context } from './serializer';
@@ -16,8 +16,8 @@ export async function* authenticationRequirement(securityRequirement: v3.Securit
 
     const auth = await single($.processInline(authentication, ref));
     const authRef = new AuthenticationReference(auth);
-    for (const scope of use(scopes)) {
-      authRef.scopes.push(use(scope));
+    for (const scope of scopes) {
+      authRef.scopes.push(scope);
     }
 
     result.authentications.push(authRef);
@@ -27,7 +27,7 @@ export async function* authenticationRequirement(securityRequirement: v3.Securit
 }
 
 export async function* authentication(scheme: v3.SecurityScheme, $: Context): AsyncGenerator<Authentication> {
-  switch (use(scheme.type)) {
+  switch (scheme.type) {
     case v3.SecurityType.ApiKey:
       return yield *apiKeyAuthentication(<v3.ApiKeySecurityScheme>scheme, $);
 
@@ -47,7 +47,7 @@ export async function* authentication(scheme: v3.SecurityScheme, $: Context): As
 function *apiKeyAuthentication(scheme: v3.ApiKeySecurityScheme, $: Context) {
   let location: ParameterLocation;
 
-  switch (use(scheme.in)) {
+  switch (scheme.in) {
     case v3.ParameterLocation.Cookie:
       location = ParameterLocation.Cookie;
       break;

--- a/adl/core/serialization/openapi/v3/security.ts
+++ b/adl/core/serialization/openapi/v3/security.ts
@@ -1,6 +1,6 @@
 import { items } from '@azure-tools/linq';
 import { JsonReference, v3 } from '@azure-tools/openapi';
-import { getSourceFile, nameOf, use, valueOf } from '@azure-tools/sourcemap';
+import { getSourceFile, nameOf, use } from '@azure-tools/sourcemap';
 import { ApiKeyAuthentication, Authentication, AuthenticationReference, AuthenticationRequirement, AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, HttpAuthentication, ImplicitOAuth2Flow, OAuth2Authentication, OAuth2Flow, OAuth2Flows, OAuth2Scope, OpenIdConnectAuthentication, ParameterLocation, PasswordOAuth2Flow } from '../../../model/http/protocol';
 import { addExtensionsToAttic, single } from '../common';
 import { Context } from './serializer';
@@ -27,7 +27,7 @@ export async function* authenticationRequirement(securityRequirement: v3.Securit
 }
 
 export async function* authentication(scheme: v3.SecurityScheme, $: Context): AsyncGenerator<Authentication> {
-  switch (valueOf(use(scheme.type))) {
+  switch (use(scheme.type)) {
     case v3.SecurityType.ApiKey:
       return yield *apiKeyAuthentication(<v3.ApiKeySecurityScheme>scheme, $);
 
@@ -47,7 +47,7 @@ export async function* authentication(scheme: v3.SecurityScheme, $: Context): As
 function *apiKeyAuthentication(scheme: v3.ApiKeySecurityScheme, $: Context) {
   let location: ParameterLocation;
 
-  switch (valueOf(use(scheme.in))) {
+  switch (use(scheme.in)) {
     case v3.ParameterLocation.Cookie:
       location = ParameterLocation.Cookie;
       break;

--- a/adl/core/serialization/openapi/v3/serializer.ts
+++ b/adl/core/serialization/openapi/v3/serializer.ts
@@ -1,5 +1,4 @@
 import { Dictionary, JsonReference, v3, vendorExtensions } from '@azure-tools/openapi';
-import { use } from '@azure-tools/sourcemap';
 import { ApiModel } from '../../../model/api-model';
 import { Host } from '../../../support/file-system';
 import { Context as Ctx, Visitor } from '../../../support/visitor';
@@ -74,9 +73,6 @@ async function processRoot(oai3: v3.Model, $: Context) {
   for await (const operation of $.processDictionary(path, oai3['x-ms-paths'])) {
     $.api.http.operations.push(operation);
   }
-
-  // we don't need this.
-  use(oai3.openapi);
 
   return $.api;
 }

--- a/adl/core/serialization/openapi/v3/server.ts
+++ b/adl/core/serialization/openapi/v3/server.ts
@@ -1,20 +1,18 @@
 import { items } from '@azure-tools/linq';
 import { v3 } from '@azure-tools/openapi';
-import { use } from '@azure-tools/sourcemap';
 import { Connection, ConnectionVariable } from '../../../model/http/protocol';
 import { Context } from './serializer';
 
 export async function *processServer(server: v3.Server, $: Context): AsyncGenerator<Connection> {
   const connection = new Connection(server.url, { description: server.description });
 
-  for (const [ name, value] of items(use(server.variables))) {
+  for (const [ name, value] of items(server.variables)) {
     const variable = new ConnectionVariable(name, {
       description: value.description,
       defaultValue: value.default,
-      allowedValues: use(value.enum, true)
+      allowedValues: value.enum
     });
 
-    use(value);
     connection.variables.push(variable);
   }
 

--- a/adl/core/support/codegen.ts
+++ b/adl/core/support/codegen.ts
@@ -1,5 +1,3 @@
-import { valueOf } from '@azure-tools/sourcemap';
-
 /**  
  * Prepares a string for use as a TypeScript identifier.
  * 
@@ -7,7 +5,6 @@ import { valueOf } from '@azure-tools/sourcemap';
  * 
 */
 export function normalizeIdentifier(value: string) {
-  value = valueOf(value);
   return /[^\w]/g.exec(value) ? `'${value.replace(/'/g, '\\\'')}'` : value;
 }
 
@@ -25,10 +22,10 @@ export function literal(value: string | number | boolean | null | undefined) {
 }
 
 export function stringLiteral(value: string) {
-  return JSON.stringify(valueOf(value) || '');
+  return JSON.stringify(value || '');
 
 }
 
 export function normalizeName(value: string ) {
-  return valueOf(value).replace(/[^\w]+/g, '_');
+  return value.replace(/[^\w]+/g, '_');
 }

--- a/adl/core/support/doc-tag.ts
+++ b/adl/core/support/doc-tag.ts
@@ -1,4 +1,3 @@
-import { valueOf } from '@azure-tools/sourcemap';
 import { fail } from 'assert';
 import { JSDoc, JSDocTag, Node } from 'ts-morph';
 
@@ -73,7 +72,6 @@ export function removeTag(target: Node | JSDocs | JSDoc, tagName: string ) {
 
 export function setTag( target: Node | JSDoc| JSDocs, tagName: string,text?: string|boolean ) {
   removeTag(target, tagName);
-  text = valueOf(text);
   switch( text ) {
     case undefined:
     case false:

--- a/adl/core/support/visitor.ts
+++ b/adl/core/support/visitor.ts
@@ -122,7 +122,7 @@ export class Visitor<TSourceModel extends OAIModel> {
 
 
   api: ApiModel;
-  tracker: Tracker;
+  // tracker: Tracker;
 
   constructor(
     api: ApiModel,
@@ -130,10 +130,11 @@ export class Visitor<TSourceModel extends OAIModel> {
     public inputType: 'oai3' | 'oai2',
     ...sourceFiles: Array<string>) {
     // the source location tracker
-    this.tracker = new Tracker();
+    // this.tracker = new Tracker();
 
     // enable target tracking on the output modle
-    this.api = TrackedTarget.track(api, [], this.tracker);
+    // this.api = TrackedTarget.track(api, [], this.tracker);
+    this.api = api;
 
     // the source files are going to be YAML/JSON files for this 
     // so we can speed up the process and grab them all and hold onto them
@@ -431,6 +432,7 @@ export class Context<TSourceModel extends OAIModel> {
   }
 
   normalizeReference(ref: string) {
+    
     const split = /(.*?)#(.*)/g.exec(ref);
     if (!split) {
       throw new Error(`$ref '${ref}' not legal`);
@@ -442,7 +444,8 @@ export class Context<TSourceModel extends OAIModel> {
     }
     // is the file pointing to this file?
     if (file === '' || file === '.' || file === './') {
-      file = getSourceFile(ref)?.filename || fail(`unable to get filename of $ref ${ref}`);
+      // file = getSourceFile(ref)?.filename || fail(`unable to get filename of $ref ${ref}`);
+      file = this.sourceFile;
     } else {
       file = this.visitor.host.fileSystem.resolve(file);
     }

--- a/adl/core/support/visitor.ts
+++ b/adl/core/support/visitor.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { items, keys, length, values } from '@azure-tools/linq';
 import { common, Dictionary, Info, isReference, isVendorExtension, JsonReference } from '@azure-tools/openapi';
-import { anonymous, getSourceFile, isAnonymous, isUsed, nameOf, Path, refTo, TrackedSource, TrackedTarget, Tracker, use, using, valueOf } from '@azure-tools/sourcemap';
+import { anonymous, getSourceFile, isAnonymous, isUsed, nameOf, Path, refTo, TrackedSource } from '@azure-tools/sourcemap';
 import { fail } from 'assert';
 import { parse } from 'yaml';
 import { Alias } from '../model/alias';
@@ -10,7 +10,6 @@ import { ApiModel } from '../model/api-model';
 import { Element } from '../model/element';
 import { Host } from './file-system';
 import { Stopwatch } from './stopwatch';
-
 
 export interface Options {
   isAnonymous?: boolean;
@@ -62,7 +61,6 @@ export function isObjectClean(obj: any): boolean {
 
 export interface SourceFile<TSourceModel extends OAIModel> {
   sourceModel: TSourceModel;
-  tracker: Tracker;
   sourceFile: string;
   visitor: Visitor<TSourceModel>;
 }
@@ -75,7 +73,7 @@ function addUnusedTo(target: any, source: any) {
   if (Array.isArray(source) && Array.isArray(target)) {
     for (const value of <any>source) {
       if (!isUsed(value)) {
-        const raw = valueOf(value);
+        const raw = value;
 
         if (typeof raw === 'object') {
           const v = Array.isArray(value) ? [] : {};
@@ -86,7 +84,7 @@ function addUnusedTo(target: any, source: any) {
           }
         }
         else {
-          target.push(valueOf(raw));
+          target.push(raw);
         }
       }
     }
@@ -99,7 +97,7 @@ function addUnusedTo(target: any, source: any) {
     }
 
     if (!isUsed(value)) {
-      const raw = valueOf(<any>value);
+      const raw = <any>value;
       if (typeof raw === 'object') {
         const v = Array.isArray(value) ? [] : {};
 
@@ -120,22 +118,11 @@ export class Visitor<TSourceModel extends OAIModel> {
   sourceFiles = new Map<string, Promise<Context<TSourceModel>>>();
   $refs = new Map<string, Array<any>>();
 
-
-  api: ApiModel;
-  // tracker: Tracker;
-
   constructor(
-    api: ApiModel,
+    public api: ApiModel,
     public host: Host,
     public inputType: 'oai3' | 'oai2',
     ...sourceFiles: Array<string>) {
-    // the source location tracker
-    // this.tracker = new Tracker();
-
-    // enable target tracking on the output modle
-    // this.api = TrackedTarget.track(api, [], this.tracker);
-    this.api = api;
-
     // the source files are going to be YAML/JSON files for this 
     // so we can speed up the process and grab them all and hold onto them
     for (const each of new Set(sourceFiles)) {
@@ -167,8 +154,8 @@ export class Visitor<TSourceModel extends OAIModel> {
 
       this.api.attic = this.api.attic || {};
       // add unused parts of the source to the attic.
-      addUnusedTo(this.api.attic, ctx.sourceModel);
-      this.host.attic(ctx.sourceFile, watch.time);
+      // addUnusedTo(this.api.attic, ctx.sourceModel);
+      // this.host.attic(ctx.sourceFile, watch.time);
     }
     return this.api;
   }
@@ -176,7 +163,7 @@ export class Visitor<TSourceModel extends OAIModel> {
   findNode(path: Path, graph: any): any {
     const [member, ...rest] = path;
     if (member && !isAnonymous(member)) {
-      const node = graph[member.valueOf()];
+      const node = graph[member];
       if (node) {
         return rest.length > 0 ? this.findNode(rest, node) : node;
       }
@@ -250,7 +237,7 @@ export class Context<TSourceModel extends OAIModel> {
     return this.visitor.host;
   }
   get apiVersion() {
-    return valueOf(this.sourceModel.info.version);
+    return this.sourceModel.info.version;
   }
   error(text: string, offendingNode: any) {
     this.host.error(text, offendingNode);
@@ -280,7 +267,7 @@ export class Context<TSourceModel extends OAIModel> {
   async *processArray<TInput, TOutput extends Element, TOptions extends Options>(action: fnAction<TSourceModel, TInput, TOutput, TOptions>, value: Array<TInput> | undefined, options?: TOptions): AsyncGenerator<TOutput> {
     if (value) {
       for (const each of value) {
-        use(value);
+      
         yield* this.process(action, each);
       }
     }
@@ -302,14 +289,10 @@ export class Context<TSourceModel extends OAIModel> {
 
       const results = new Array<TOutput>();
       // ok, call the action
-      for await (let result of action(value!, this, options)) {
-        // we're going to mark the original value as used
-        // note: does not mark the children as used. 
-        use(value);
-
+      for await (const result of action(value!, this, options)) {
         if (result !== undefined) {
           // we got back a value for that.
-          result = TrackedTarget.track(result);
+          //result = TrackedTarget.track(result);
 
           // track it so we don't redo it if asked for it again later.
           this.visitor.$refs.set(ref, results);
@@ -319,7 +302,7 @@ export class Context<TSourceModel extends OAIModel> {
             // when a result is returned up the chain more than once
             result.addVersionInfo({
               // deprecated isn't on everything, but this is safe when it's not there
-              deprecated: use((<any>value).deprecated) ? this.apiVersion : undefined,
+              deprecated: (<any>value).deprecated ? this.apiVersion : undefined,
               added: this.apiVersion,
             });
             result.addInternalData(this.visitor.inputType, { preferredFile: getSourceFile(value) });
@@ -338,7 +321,7 @@ export class Context<TSourceModel extends OAIModel> {
       // when a result is returned up the chain more than once
       result.addVersionInfo({
         // deprecated isn't on everything, but this is safe when it's not there
-        deprecated: use((<any>value).deprecated) ? this.apiVersion : undefined,
+        deprecated: (<any>value).deprecated ? this.apiVersion : undefined,
         added: this.apiVersion,
       });
       result.addInternalData(this.visitor.inputType, { preferredFile: getSourceFile(value) });
@@ -356,7 +339,6 @@ export class Context<TSourceModel extends OAIModel> {
         const name = options?.isAnonymous ? anonymous(action.name) : nameOf(value);
 
         const { $ref, file, path } = this.normalizeReference(value.$ref);
-        use(value.$ref);
 
         const targets = <Array<TOut>>this.visitor.$refs.get($ref);
         if (targets) {
@@ -407,12 +389,8 @@ export class Context<TSourceModel extends OAIModel> {
       // ok, call the action
       result = await action(value!, this, options);
 
-      // we're going to mark the original value as used
-      // note: does not mark the children as used. 
-      use(value);
-
       if (result !== undefined) {
-        result = TrackedTarget.track(result);
+        //result = TrackedTarget.track(result);
         // we got back a value for that.
 
         // track it so we don't redo it if asked for it again later.
@@ -420,7 +398,7 @@ export class Context<TSourceModel extends OAIModel> {
 
         result.addVersionInfo({
           // deprecated isn't on everything, but this is safe when it's not there
-          deprecated: using((<any>value).deprecated, this.apiVersion),
+          deprecated: (<any>value).deprecated ? this.apiVersion: undefined,
           added: this.apiVersion,
         });
         result.addInternalData(this.visitor.inputType, { preferredFile: getSourceFile(value) });

--- a/adl/core/support/visitor.ts
+++ b/adl/core/support/visitor.ts
@@ -292,7 +292,6 @@ export class Context<TSourceModel extends OAIModel> {
       for await (const result of action(value!, this, options)) {
         if (result !== undefined) {
           // we got back a value for that.
-          //result = TrackedTarget.track(result);
 
           // track it so we don't redo it if asked for it again later.
           this.visitor.$refs.set(ref, results);
@@ -390,7 +389,6 @@ export class Context<TSourceModel extends OAIModel> {
       result = await action(value!, this, options);
 
       if (result !== undefined) {
-        //result = TrackedTarget.track(result);
         // we got back a value for that.
 
         // track it so we don't redo it if asked for it again later.

--- a/adl/core/test/load-openapi2.ts
+++ b/adl/core/test/load-openapi2.ts
@@ -19,7 +19,7 @@ const scenarios = `${__dirname}/../../../test/scenarios/v2`;
 
 async function checkAttic(api: ApiModel, errors: Errors, atticOutput: string) {
   if (api.attic) {
-    const attic = <v2.Model>api.attic.valueOf();
+    const attic = <v2.Model>api.attic;
 
     // verify that the attic does not have things we expect to be done
     /*
@@ -32,7 +32,7 @@ async function checkAttic(api: ApiModel, errors: Errors, atticOutput: string) {
     errors.check(() => equal(attic.basePath, undefined, 'Should not have basePath left in attic'));
     errors.check(() => equal(attic.securityDefinitions, undefined, 'Should not have securityDefinitions section left in attic'));
 */
-    await writeFile(atticOutput, serialize(api.attic.valueOf()));
+    await writeFile(atticOutput, serialize(api.attic));
     delete api.attic;
   }
 }
@@ -65,7 +65,7 @@ describe('Load Single OAI2 files', () => {
 
       // reset timer
       stopwatch.time;
-      const content = serialize(api.valueOf());
+      const content = serialize(api);
       console.log(chalk.cyan(`      serialize: '${file}' ${formatDuration(stopwatch.time)} `));
       // write out yaml 
       
@@ -107,7 +107,7 @@ describe('Load Multiple OAI2 files', () => {
       await checkAttic(api, errors, atticOutput);
 
       const stopwatch = new Stopwatch();
-      const content = serialize(api.valueOf());
+      const content = serialize(api);
       console.log(chalk.cyan(`      serialize: '${folder}' ${formatDuration(stopwatch.time)} `));
       
       await writeFile(apiOutput, content);

--- a/adl/core/test/load-openapi3.ts
+++ b/adl/core/test/load-openapi3.ts
@@ -19,7 +19,7 @@ const scenarios = `${__dirname}/../../../test/scenarios/v3`;
 
 async function checkAttic(api: ApiModel, errors: Errors, atticOutput: string) {
   if (api.attic) {
-    const attic = <v3.Model>api.attic.valueOf();
+    const attic = <v3.Model>api.attic;
 
     /*
     // verify that the attic does not have things we expect to be done
@@ -38,7 +38,7 @@ async function checkAttic(api: ApiModel, errors: Errors, atticOutput: string) {
 
     errors.check(() => equal(attic.components, undefined, 'Should not have components section left in attic'));
 */
-    await writeFile(atticOutput, serialize(api.attic.valueOf()));
+    await writeFile(atticOutput, serialize(api.attic));
     delete api.attic;
   }
 }
@@ -77,7 +77,7 @@ describe('Load Single OAI3 files', () => {
       // reset timer
       stopwatch.time;
 
-      const content = serialize(api.valueOf());
+      const content = serialize(api);
       console.log(chalk.cyan(`      serialize: '${file}' ${formatDuration(stopwatch.time)} `));
       // write out yaml 
       await writeFile(apiOutput, content);
@@ -117,7 +117,7 @@ describe('Load Multiple OAI3 files', () => {
       await checkAttic(api, errors, atticOutput);
 
       const stopwatch = new Stopwatch();
-      const content = serialize(api.valueOf());
+      const content = serialize(api);
       console.log(chalk.cyan(`      serialize: '${folder}' ${formatDuration(stopwatch.time)} `));
       await writeFile(apiOutput, content);
         

--- a/adl/core/test/serialization.ts
+++ b/adl/core/test/serialization.ts
@@ -1,5 +1,5 @@
 import { linq } from '@azure-tools/linq';
-import { isAnonymous, valueOf } from '@azure-tools/sourcemap';
+import { isAnonymous } from '@azure-tools/sourcemap';
 import { AST, CST, Document } from 'yaml';
 import { Schema, YAMLMap } from 'yaml/types';
 import { parseMap } from 'yaml/util';
@@ -64,8 +64,8 @@ export const elementTag = <Schema.CustomTag>{
     v !== undefined && 
     v !== null && 
     typeof v === 'object' && 
-    !Array.isArray(valueOf(v)) && 
-    (v instanceof ApiModel || v instanceof Element || valueOf(v).added),
+    !Array.isArray(v) && 
+    (v instanceof ApiModel || v instanceof Element || v.added),
   default: true,
   tag: 'tag:yaml.org,2002:map',
   resolve: (doc: Document, cst: CST.Node): AST.Node => {

--- a/adl/sourcemap/proxies.ts
+++ b/adl/sourcemap/proxies.ts
@@ -34,12 +34,8 @@ enum SpecialProperties {
   RefToHere = '##RefToHere', // gets the JSON Reference to the tracked source
 }
 
-export function use<T>(value: T, recursive = false): T {
-  return value;
-}
-
 /** marks a member in a tracked source model as 'used' */
-export function _use<T>(value: T, recursive = false): T {
+export function use<T>(value: T, recursive = false): T {
   if (value === undefined || value === null || typeof value === 'function') {
     return value;
   }
@@ -57,7 +53,7 @@ export function _use<T>(value: T, recursive = false): T {
   return value;
 }
 
-export function _unusedMembers<T>(value: T) {
+export function unusedMembers<T>(value: T) {
   if (value === undefined || value === null || typeof valueOf(value) !== 'object') {
     return [];
   }

--- a/adl/sourcemap/proxies.ts
+++ b/adl/sourcemap/proxies.ts
@@ -34,8 +34,12 @@ enum SpecialProperties {
   RefToHere = '##RefToHere', // gets the JSON Reference to the tracked source
 }
 
-/** marks a member in a tracked source model as 'used' */
 export function use<T>(value: T, recursive = false): T {
+  return value;
+}
+
+/** marks a member in a tracked source model as 'used' */
+export function _use<T>(value: T, recursive = false): T {
   if (value === undefined || value === null || typeof value === 'function') {
     return value;
   }
@@ -53,7 +57,7 @@ export function use<T>(value: T, recursive = false): T {
   return value;
 }
 
-export function unusedMembers<T>(value: T) {
+export function _unusedMembers<T>(value: T) {
   if (value === undefined || value === null || typeof valueOf(value) !== 'object') {
     return [];
   }
@@ -97,7 +101,8 @@ export function isUsed<T>(value: T): boolean {
     return true;
   }
   // ask the proxy if the isUsed is set.
-  return (<any>value)[SpecialProperties.IsUsed] === true;
+  /// return (<any>value)[SpecialProperties.IsUsed] === true;
+  return true;
 }
 
 export function getSourceFile(value: any): SourceFile | undefined {
@@ -271,7 +276,8 @@ export class TrackedSource<T extends Object, instanceType> {
     }
     
     const value = (<any>this.instance)[property];
-    if (value === undefined || value === null) {
+    // if (value === undefined || value === null) {
+    if( typeof value !== 'object') {
       return value;
     }
     switch (typeof value) {

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/apimanagement.attic.yaml
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/apimanagement.attic.yaml
@@ -1,1 +1,0 @@
-not right now

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AsyncOperationStatus.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AsyncOperationStatus.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description Status of an async operation.
  * @since 2019-12-01
  */

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AuthorizationMethod.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AuthorizationMethod.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @since 2019-12-01
  */
 export enum AuthorizationMethod {

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/GroupType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/GroupType.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description Group type.
  * @todo temporary-reuse-marker
  * @todo temporary-reuse-marker

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/KeyType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/KeyType.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description The Key to be used to generate token for user.
  * @todo temporary-reuse-marker
  * @todo temporary-reuse-marker

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ProductState.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ProductState.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description whether product is published or not. Published products are discoverable by users of developer portal. Non published products are visible only to administrators. Default state of Product is notPublished.
  * @since 2019-12-01
  */

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/Protocol.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/Protocol.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @todo temporary-reuse-marker
  * @todo temporary-reuse-marker
  * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ProvisioningState.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ProvisioningState.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description Provisioning state.
  * @since 2019-12-01
  */

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/SubscriptionState.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/SubscriptionState.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description Subscription state. Possible states are * active – the subscription is active, * suspended – the subscription is blocked, and the subscriber cannot call any APIs of the product, * submitted – the subscription request has been made by the developer, but has not yet been approved or rejected, * rejected – the subscription request has been denied by an administrator, * cancelled – the subscription has been cancelled by the developer or administrator, * expired – the subscription reached its expiration date and was deactivated.
  * @todo temporary-reuse-marker
  * @todo temporary-reuse-marker

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiCollection.ts
@@ -8,7 +8,7 @@ export interface ApiCollection {
      * @description Page values.
      * @since 2019-12-01
      */
-    readonly value: Array<ApiContract> & ;
+    readonly value: Array<ApiContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiReleaseCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiReleaseCollection.ts
@@ -8,7 +8,7 @@ export interface ApiReleaseCollection {
      * @description Page values.
      * @since 2019-12-01
      */
-    readonly value: Array<ApiReleaseContract> & ;
+    readonly value: Array<ApiReleaseContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiRevisionCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiRevisionCollection.ts
@@ -8,7 +8,7 @@ export interface ApiRevisionCollection {
      * @description Page values.
      * @since 2019-12-01
      */
-    readonly value: Array<ApiRevisionContract> & ;
+    readonly value: Array<ApiRevisionContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/GatewayCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/GatewayCollection.ts
@@ -8,7 +8,7 @@ export interface GatewayCollection {
      * @description Page values.
      * @since 2019-12-01
      */
-    readonly value: Array<GatewayContract> & ;
+    readonly value: Array<GatewayContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/GatewayHostnameConfigurationCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/GatewayHostnameConfigurationCollection.ts
@@ -8,7 +8,7 @@ export interface GatewayHostnameConfigurationCollection {
      * @description Page values.
      * @since 2019-12-01
      */
-    readonly value: Array<GatewayHostnameConfigurationContract> & ;
+    readonly value: Array<GatewayHostnameConfigurationContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueAttachmentCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueAttachmentCollection.ts
@@ -8,7 +8,7 @@ export interface IssueAttachmentCollection {
      * @description Issue Attachment values.
      * @since 2019-12-01
      */
-    readonly value: Array<IssueAttachmentContract> & ;
+    readonly value: Array<IssueAttachmentContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueCollection.ts
@@ -8,7 +8,7 @@ export interface IssueCollection {
      * @description Issue values.
      * @since 2019-12-01
      */
-    readonly value: Array<IssueContract> & ;
+    readonly value: Array<IssueContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueCommentCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueCommentCollection.ts
@@ -8,7 +8,7 @@ export interface IssueCommentCollection {
      * @description Issue Comment values.
      * @since 2019-12-01
      */
-    readonly value: Array<IssueCommentContract> & ;
+    readonly value: Array<IssueCommentContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/OperationCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/OperationCollection.ts
@@ -8,7 +8,7 @@ export interface OperationCollection {
      * @description Page values.
      * @since 2019-12-01
      */
-    readonly value: Array<OperationContract> & ;
+    readonly value: Array<OperationContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/OperationResultContract.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/OperationResultContract.ts
@@ -39,5 +39,5 @@ export interface OperationResultContract {
      * @description This property if only provided as part of the TenantConfiguration_Validate operation. It contains the log the entities which will be updated/created/deleted as part of the TenantConfiguration_Deploy operation.
      * @since 2019-12-01
      */
-    readonly actionLog: Array<OperationResultLogItemContract> & ;
+    readonly actionLog: Array<OperationResultLogItemContract>;
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/SchemaCollection.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/SchemaCollection.ts
@@ -8,7 +8,7 @@ export interface SchemaCollection {
      * @description Api Schema Contract value.
      * @since 2019-12-01
      */
-    readonly value: Array<SchemaContract> & ;
+    readonly value: Array<SchemaContract>;
     /**
      * @description Next page link if any.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/UserContractProperties.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/UserContractProperties.ts
@@ -29,5 +29,5 @@ export interface UserContractProperties extends UserEntityBaseParameters {
      * @description Collection of groups user is part of.
      * @since 2019-12-01
      */
-    readonly groups: Array<GroupContractProperties> & ;
+    readonly groups: Array<GroupContractProperties>;
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/AccessPolicyUpdateKind.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/AccessPolicyUpdateKind.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description Name of the operation
  * @since 2019-09-01
  */

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/CreateMode.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/CreateMode.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description The vault's create mode to indicate whether the vault need to be recovered or not.
  * @todo temporary-reuse-marker
  * @since 2019-09-01

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/Reason.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/Reason.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description The reason that a vault name could not be used. The Reason element is only returned if NameAvailable is false.
  * @since 2019-09-01
  */

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/SkuName.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/SkuName.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description SKU name to specify whether the key vault is a standard vault or a premium vault.
  * @since 2019-09-01
  */

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/Type.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/Type.ts
@@ -1,6 +1,5 @@
 
 /**
- * @extensible
  * @description The type of resource, Microsoft.KeyVault/vaults
  * @since 2019-09-01
  */

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/management-keyvault.attic.yaml
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/management-keyvault.attic.yaml
@@ -1,1 +1,0 @@
-not right now

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/models/PrivateLinkResourceProperties.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/models/PrivateLinkResourceProperties.ts
@@ -13,7 +13,7 @@ export interface PrivateLinkResourceProperties {
      * @description Required member names of private link resource.
      * @since 2019-09-01
      */
-    readonly requiredMembers: Array<string> & ;
+    readonly requiredMembers: Array<string>;
     /**
      * @description Required DNS zone names of the the private link resource.
      * @since 2019-09-01

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/models/VaultProperties.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/models/VaultProperties.ts
@@ -76,5 +76,5 @@ export interface VaultProperties {
      * @description List of private endpoint connections associated with the key vault.
      * @since 2019-09-01
      */
-    readonly privateEndpointConnections: Array<PrivateEndpointConnectionItem> & ;
+    readonly privateEndpointConnections: Array<PrivateEndpointConnectionItem>;
 }

--- a/adl/test/scenarios/v2/single/output/air-epa-gov/air-epa-gov.attic.yaml
+++ b/adl/test/scenarios/v2/single/output/air-epa-gov/air-epa-gov.attic.yaml
@@ -1,1 +1,0 @@
-not right now

--- a/adl/test/scenarios/v2/single/output/github/github.attic.yaml
+++ b/adl/test/scenarios/v2/single/output/github/github.attic.yaml
@@ -1,1 +1,0 @@
-not right now

--- a/adl/test/scenarios/v2/single/output/github/models/trees.ts
+++ b/adl/test/scenarios/v2/single/output/github/models/trees.ts
@@ -1,5 +1,4 @@
 import { tree } from './tree';
-import { tree } from './tree';
 /**
  * @since v3
  */

--- a/adl/test/scenarios/v3/multiple/petstore/output/petstore.attic.yaml
+++ b/adl/test/scenarios/v3/multiple/petstore/output/petstore.attic.yaml
@@ -1,1 +1,0 @@
-not right now

--- a/adl/test/scenarios/v3/single/output/ablyio/ablyio.attic.yaml
+++ b/adl/test/scenarios/v3/single/output/ablyio/ablyio.attic.yaml
@@ -1,1 +1,0 @@
-not right now

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/aws-app-insights.attic.yaml
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/aws-app-insights.attic.yaml
@@ -1,1 +1,0 @@
-not right now

--- a/adl/test/scenarios/v3/single/output/google-analytics/google-analytics.attic.yaml
+++ b/adl/test/scenarios/v3/single/output/google-analytics/google-analytics.attic.yaml
@@ -1,1 +1,0 @@
-not right now

--- a/adl/test/scenarios/v3/single/output/petstore/petstore.attic.yaml
+++ b/adl/test/scenarios/v3/single/output/petstore/petstore.attic.yaml
@@ -1,1 +1,0 @@
-not right now

--- a/adl/test/scenarios/v3/single/output/twitter/twitter.attic.yaml
+++ b/adl/test/scenarios/v3/single/output/twitter/twitter.attic.yaml
@@ -1,1 +1,0 @@
-not right now


### PR DESCRIPTION
This PR: 
- gets rid of all the target node tracking
- and removes the source tracking on all non-object nodes (we still need it on object nodes to know the current location/name of the current node)

I removed all the `use(...)` calls, and the `valueOf(...)` calls, since they are never needed (because all primitive/string values are always the unboxed value now)

This also means we have no `isUsed` functionality for now, nor any ability to know what didn't get processed. 

After we have all the processing done, I'll revisit how to track usage and create source map information for the nodes (since I already have the plumbing and know that I can do it with the proxy, it's just a matter of inserting the functionality in without breaking the test outputs.)


