### PR TITLE
Separate map of reference -> element by type

### DIFF
--- a/adl/core/serialization/openapi/v3/header.ts
+++ b/adl/core/serialization/openapi/v3/header.ts
@@ -1,5 +1,5 @@
 import { v3 } from '@azure-tools/openapi';
-import { anonymous, nameOf, refTo, use } from '@azure-tools/sourcemap';
+import { anonymous, nameOf, use } from '@azure-tools/sourcemap';
 import { Header } from '../../../model/http/header';
 import { singleOrDefault } from '../common';
 import { processInline } from './schema';
@@ -27,11 +27,6 @@ export async function* header(header: v3.Header, $: Context, options?: { isAnony
     // set the style value
     style: use(header.style),
   });
-
-  // best practice - put this into the $refs collection early 
-  if (!options?.isAnonymous) {
-    visitor.$refs.set(refTo(header), [httpHeader]);
-  }
 
   // preserve data that we're not using
   httpHeader.addToAttic('example', use(header.example));

--- a/adl/core/support/visitor.ts
+++ b/adl/core/support/visitor.ts
@@ -115,10 +115,37 @@ function addUnusedTo(target: any, source: any) {
   }
 }
 
+class RefMap {
+  private map = new Map<string, Map<string, Array<any>>>();
+
+  get(type: string, ref: string): Array<any> | undefined {
+    const map2 = this.map.get(type);
+    if (!map2) {
+      return undefined;
+    }
+
+    const values = map2.get(ref);
+    if (!values) {
+      return undefined;
+    }
+
+    return values;
+  }
+
+  set(type: string, ref: string, values: Array<any>): void {
+    let map2 = this.map.get(type);
+    if (!map2) {
+      map2 = new Map<string, Array<any>>();
+      this.map.set(type, map2);
+    }
+    map2.set(ref, values);
+  }
+}
+
 export class Visitor<TSourceModel extends OAIModel> {
   key = '';
   sourceFiles = new Map<string, Promise<Context<TSourceModel>>>();
-  $refs = new Map<string, Array<any>>();
+  $refs = new RefMap();
 
 
   api: ApiModel;
@@ -291,7 +318,7 @@ export class Context<TSourceModel extends OAIModel> {
       // see if we've processed this node before.
       // todo: hmmm. $refs can only return a single value? This may need rethinking...
       const ref = refTo(value);
-      const refResult = this.visitor.$refs.get(ref);
+      const refResult = this.visitor.$refs.get(action.name, ref);
       if (refResult) {
         for (const each of refResult) {
           yield each;
@@ -311,7 +338,7 @@ export class Context<TSourceModel extends OAIModel> {
           result = TrackedTarget.track(result);
 
           // track it so we don't redo it if asked for it again later.
-          this.visitor.$refs.set(ref, results);
+          this.visitor.$refs.set(action.name, ref, results);
           results.push(result);
           if (result.versionInfo.length === 0) {
             // only add this if we haven't added it before
@@ -357,7 +384,7 @@ export class Context<TSourceModel extends OAIModel> {
         const { $ref, file, path } = this.normalizeReference(value.$ref);
         use(value.$ref);
 
-        const targets = <Array<TOut>>this.visitor.$refs.get($ref);
+        const targets = <Array<TOut>>this.visitor.$refs.get(action.name, $ref);
         if (targets) {
           // already processed?
           for (const target of targets) {
@@ -398,13 +425,13 @@ export class Context<TSourceModel extends OAIModel> {
 
       // see if we've processed this node before.
       const ref = refTo(value);
-      let result = <TOutput | undefined>this.visitor.$refs.get(ref);
-      if (result) {
-        return result;
+      const results = this.visitor.$refs.get(action.name, ref);
+      if (results) {
+        return results[0];
       }
 
       // ok, call the action
-      result = await action(value!, this, options);
+      let result = await action(value!, this, options);
 
       // we're going to mark the original value as used
       // note: does not mark the children as used. 
@@ -415,7 +442,7 @@ export class Context<TSourceModel extends OAIModel> {
         // we got back a value for that.
 
         // track it so we don't redo it if asked for it again later.
-        this.visitor.$refs.set(ref, [result]);
+        this.visitor.$refs.set(action.name, ref, [result]);
 
         result.addVersionInfo({
           // deprecated isn't on everything, but this is safe when it's not there


### PR DESCRIPTION
There are cases where we process the same JSON element as two different types. For example, parameters are also processed as schemas. So keep separate maps per type.

Splitting this off from my operations branch, which still needs a bunch of cleanup, and I thought this might be worth some discussion on its own sooner.