### PR TITLE
Use type aliases for header definitions

### DIFF
--- a/adl/core/model/http/header.ts
+++ b/adl/core/model/http/header.ts
@@ -1,20 +1,15 @@
 import { Element } from '../element';
-import { TypeReference } from '../schema/type';
+import { SchemaTypeReference } from '../schema/type';
 
 export class Header extends Element {
-  // the header name in container. might not be unique in parent? 
-  name!: string;
-
   /** description of the HTTP Header */
   description?: string;
 
-  /** the serialization style of the header */
-  style: any;
-
-  /** the schema for the header */
-  typeRef?: TypeReference;
-
-  constructor(initializer?: Partial<Header>) {
+  /**
+   * @param name The name of the header
+   * @param typeRef The schema of the header
+   */
+  constructor(public name: string, public typeRef: SchemaTypeReference, initializer?: Partial<Header>) {
     super();
     this.initialize(initializer);
   }

--- a/adl/core/model/http/response.ts
+++ b/adl/core/model/http/response.ts
@@ -1,7 +1,6 @@
-import { Alias } from '../alias';
 import * as base from '../operation';
+import { HeaderTypeReference } from '../schema/type';
 import { Identity } from '../types';
-import { Header } from './header';
 
 export class Response extends base.Response {
   /**
@@ -10,7 +9,7 @@ export class Response extends base.Response {
    */
   description?: string;
 
-  headers = new Array<Header|Alias<Header>>();
+  headers = new Array<HeaderTypeReference>();
 
   /**
    * 

--- a/adl/core/model/schema/constraint.ts
+++ b/adl/core/model/schema/constraint.ts
@@ -1,5 +1,5 @@
 import { ParameterDeclaration, PropertyDeclaration } from 'ts-morph';
-import { stringLiteral } from '../../support/codegen';
+import { stringLiteral, TypeSyntax } from '../../support/codegen';
 import { Identity } from '../types';
 import { Schema } from './schema';
 import { TypeReference } from './type';
@@ -233,7 +233,7 @@ export const Constraints = {
 export function addConstraint( type: TypeReference, constraint: ConstraintReference): TypeReference {
   return {
     ... type,
-    declaration: `${type.declaration} & ${constraint.implementation}`
+    declaration: new TypeSyntax(`${type.declaration} & ${constraint.implementation}`)
   };
 }
 
@@ -250,6 +250,6 @@ export const Encodings= {
 export function addEncoding(type: TypeReference, encoding: EncodingReference): TypeReference {
   return {
     ...type,
-    declaration: `${type.declaration} & ${encoding.implementation}`
+    declaration: new TypeSyntax(`${type.declaration} & ${encoding.implementation}`)
   };
 }

--- a/adl/core/model/schema/default.ts
+++ b/adl/core/model/schema/default.ts
@@ -1,6 +1,7 @@
 import { Identity } from '../types';
 import { Schema } from './schema';
 import { TypeReference } from './type';
+import { TypeSyntax } from '../../support/codegen';
 
 
 export class Default extends Schema {
@@ -20,7 +21,7 @@ export class ServerDefaultValue extends Schema {
 export function addDefault(type: TypeReference, defaultValue: any): TypeReference {
   return {
     ...type,
-    declaration: `${type.declaration} /* todo: add defaultValue '${JSON.stringify(defaultValue) }' */`
+    declaration: new TypeSyntax(`${type.declaration} /* todo: add defaultValue '${JSON.stringify(defaultValue) }' */`)
   };
 
 }

--- a/adl/core/model/schema/enum.ts
+++ b/adl/core/model/schema/enum.ts
@@ -1,5 +1,5 @@
 import { isAnonymous } from '@azure-tools/sourcemap';
-import { literal, normalizeIdentifier } from '../../support/codegen';
+import { literal, normalizeIdentifier, TypeSyntax } from '../../support/codegen';
 import { createDocs } from '../../support/doc-tag';
 import { ApiModel } from '../api-model';
 import { Collection, Identity } from '../types';
@@ -13,7 +13,7 @@ export interface Enum extends Schema {
 
 export interface EnumValue {
   name?: string;
-  description?: string;
+  summary?: string;
   value: any;
 }
 
@@ -28,7 +28,7 @@ export function createEnum(api: ApiModel, identity: Identity, values: Array<Enum
       // which means there can be multiple declarations for the same enum 
       // so, we just return the existing enum by name 
       return {
-        declaration: existing.getName(),
+        declaration: new TypeSyntax(existing.getName()),
         sourceFile: file,
         requiredReferences: [],
       };
@@ -51,7 +51,7 @@ export function createEnum(api: ApiModel, identity: Identity, values: Array<Enum
 
     // return the reference to this enum 
     return {
-      declaration: name,
+      declaration: new TypeSyntax(name),
       sourceFile: file,
       requiredReferences: []
     };
@@ -59,7 +59,7 @@ export function createEnum(api: ApiModel, identity: Identity, values: Array<Enum
 
   // anonymous enums are far simpler, since they are purely inline information
   return {
-    declaration: values.map(v => literal(v.value)).join(' | '),
+    declaration: new TypeSyntax(values.map(v => literal(v.value)).join(' | ')),
     requiredReferences: [],
   };
 }

--- a/adl/core/model/schema/schemas.ts
+++ b/adl/core/model/schema/schemas.ts
@@ -6,10 +6,12 @@ import { Default } from './default';
 import { Enum } from './enum';
 import { AndSchema, AnyOfSchema, XorSchema } from './group';
 import { ObjectSchemaImpl } from './object';
+import { SchemaTypeReference } from './type';
+import { TypeSyntax } from '../../support/codegen';
 
-function createPrimitiveSchema( declaration: string ) {
+function createPrimitiveSchema( declaration: string ): SchemaTypeReference {
   return {
-    declaration: declaration,
+    declaration: new TypeSyntax(declaration),
     requiredReferences: []
   };
 }

--- a/adl/core/model/schema/type.ts
+++ b/adl/core/model/schema/type.ts
@@ -1,7 +1,5 @@
 import { SourceFile } from 'ts-morph';
-
-
-export type TypeDeclaration = string;
+import { TypeSyntax } from '../../support/codegen';
 
 export interface TypeReference {
   /** 
@@ -15,7 +13,7 @@ export interface TypeReference {
    *     enum  '"http" | "https"'
    * 
    */
-  readonly declaration: TypeDeclaration;
+  readonly declaration: TypeSyntax;
 
   /**
    * This is a list of imports that should be applied to the file that is consuming 
@@ -35,6 +33,11 @@ export interface TypeReference {
   readonly sourceFile?: SourceFile;
 }
 
-export interface ParameterReference {
+export interface SchemaTypeReference extends TypeReference {
+}
 
+export interface ParameterTypeReference extends TypeReference {
+}
+
+export interface HeaderTypeReference extends TypeReference {
 }

--- a/adl/core/serialization/openapi/common/schema.ts
+++ b/adl/core/serialization/openapi/common/schema.ts
@@ -3,8 +3,8 @@ import { anonymous, nameOf } from '@azure-tools/sourcemap';
 import { createTypeAlias } from '../../../model/schema/alias';
 import { addEncoding, EncodingReference } from '../../../model/schema/constraint';
 import { addDefault } from '../../../model/schema/default';
-import { createEnum } from '../../../model/schema/enum';
-import { TypeReference } from '../../../model/schema/type';
+import { createEnum, EnumValue } from '../../../model/schema/enum';
+import { SchemaTypeReference } from '../../../model/schema/type';
 import { Context, OAIModel } from '../../../support/visitor';
 
 
@@ -49,75 +49,75 @@ export function versionInfo<T extends OAIModel>($: Context<T>, versionedElement:
   };
 }
 
-export async function processCharSchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processCharSchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.char, $);
 }
 
 
-export async function processDateSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processDateSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.date, $);
 }
 
-export async function processTimeSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processTimeSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.time, $);
 }
 
-export async function processDateTimeSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>, encoding?: EncodingReference): Promise<TypeReference> {
+export async function processDateTimeSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>, encoding?: EncodingReference): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.dateTime, $, encoding);
 }
 
-export async function processDurationSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processDurationSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.duration, $);
 }
 
-export async function processUuidSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processUuidSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.uuid, $);
 }
 
-export async function processUriSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processUriSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.uri, $);
 }
 
-export async function processPasswordSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processPasswordSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.password, $);
 }
 
-export async function processOdataSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processOdataSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.odata, $);
 }
 
-export async function processBooleanSchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>, options?: Options): Promise<TypeReference> {
+export async function processBooleanSchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>, options?: Options): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
   return wrapWithAliasIfNeeded(schema, $.api.schemas.primitives.boolean, $);
 }
 
-export async function processByteArraySchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processByteArraySchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   // throws on error.
   $.assertNoForbiddenProperties(schema, ...<any>stringProperties, ...<any>objectProperties, ...<any>numberProperties);
     
   return $.api.schemas.primitives.byteArray;
 }
 
-export function wrapWithAliasIfNeeded<T extends OAIModel>(schema: v3.Schema | v2.Schema, type: TypeReference, $: Context<T>, encoding?: EncodingReference) {
+export function wrapWithAliasIfNeeded<T extends OAIModel>(schema: v3.Schema | v2.Schema, type: SchemaTypeReference, $: Context<T>, encoding?: EncodingReference) {
   if (schema.default || schema.description || schema.title || (<any>schema).nullable || schema['x-nullable'] || (<any>schema).readOnly || encoding) {
     let alias = createTypeAlias($.api, anonymous(nameOf(schema)), type, commonProperties(schema));
     
@@ -141,7 +141,7 @@ export function wrapWithAliasIfNeeded<T extends OAIModel>(schema: v3.Schema | v2
   return type;
 }
 
-export async function processNumberSchema<T extends OAIModel>(schema: v2.Schema|v3.Schema, $: Context<T>, options?: Options ): Promise<TypeReference> {
+export async function processNumberSchema<T extends OAIModel>(schema: v2.Schema|v3.Schema, $: Context<T>, options?: Options ): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>stringProperties, ...<any>objectProperties, ...<any>arrayProperties);
   
   switch (schema.format) {
@@ -158,7 +158,7 @@ export async function processNumberSchema<T extends OAIModel>(schema: v2.Schema|
 }
 
 
-export async function processIntegerSchema<T extends OAIModel>(schema: v2.Schema | v3.Schema, $: Context<T>, options?: Options ): Promise<TypeReference> {
+export async function processIntegerSchema<T extends OAIModel>(schema: v2.Schema | v3.Schema, $: Context<T>, options?: Options ): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>stringProperties, ...<any>objectProperties, ...<any>arrayProperties);
 
   switch (schema.format) {
@@ -177,20 +177,26 @@ export async function processIntegerSchema<T extends OAIModel>(schema: v2.Schema
   }
 }
 
-export async function processFileSchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>, options?: Options): Promise<TypeReference> {
+export async function processFileSchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>, options?: Options): Promise<SchemaTypeReference> {
   return $.api.schemas.primitives.file;
 }
 
-export async function processAnySchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<TypeReference> {
+export async function processAnySchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {
   return $.api.schemas.primitives.any;
 }
 
-export async function processEnumSchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>, options?: Options): Promise<TypeReference> {
+export async function processEnumSchema<T extends OAIModel>(schema: v3.Schema | v2.Schema, $: Context<T>, options?: Options): Promise<SchemaTypeReference> {
   const schemaEnum = schema.enum || [];
   const xmsEnum = schema['x-ms-enum'] || {};
-  const values: Array<XMSEnumValue> = xmsEnum.values || schemaEnum.map(value => ({ value }));
+  const xmsValues: Array<XMSEnumValue> = xmsEnum.values || schemaEnum.map(value => ({ value }));
   const name = xmsEnum.name || (options?.isAnonymous ? anonymous('enum') : nameOf(schema));
   const extensible = xmsEnum.modelAsString;
+
+  const values: Array<EnumValue> = xmsValues.map(value => ({
+    value: value.value,
+    name: value.name,
+    summary: value.description,
+  }));
 
   // enums are a bit funny -- they can define their name inside the x-ms-enum declaration 
   // which means there can be multiple declarations for the same enum 

--- a/adl/core/serialization/openapi/v3/components.ts
+++ b/adl/core/serialization/openapi/v3/components.ts
@@ -1,7 +1,6 @@
 import { items } from '@azure-tools/linq';
 import { v3 } from '@azure-tools/openapi';
 import { Element } from '../../../model/element';
-import { header } from './header';
 import { parameter } from './parameter';
 import { requestBody } from './request-body';
 import { response } from './response';
@@ -29,9 +28,9 @@ export async function* processComponents(components: v3.Components, $: Context):
   // for (const { key, value: extension } of vendorExtensions(components.headers)) {
   // ... do something ...
   // }
-  for await (const h of $.processDictionary(header, components.headers)) {
-    $.api.http.headers.push(h);
-  }
+
+  // NOTE: components.headers are not processed here because we need to traverse
+  //       via references to get the header client names.
 
   for await (const p of $.processDictionary(parameter, components.parameters)) {
     $.api.http.parameters.push(p);

--- a/adl/core/serialization/openapi/v3/header.ts
+++ b/adl/core/serialization/openapi/v3/header.ts
@@ -1,35 +1,68 @@
-import { v3 } from '@azure-tools/openapi';
-import { nameOf } from '@azure-tools/sourcemap';
-import { Header } from '../../../model/http/header';
+import { isReference, v3 } from '@azure-tools/openapi';
+import { anonymous, nameOf, refTo } from '@azure-tools/sourcemap';
+import { ts } from 'ts-morph';
+import { createTypeAlias } from '../../../model/schema/alias';
+import { HeaderTypeReference } from '../../../model/schema/type';
+import { TypeSyntax } from '../../../support/codegen';
 import { processSchema } from '../v3/schema';
 import { Context } from './serializer';
 
+export async function processHeader(header: v3.Header | v3.HeaderReference, $: Context, clientName: string, options?: { isAnonymous: boolean }): Promise<HeaderTypeReference> {
+  // Header names appear where headers are consumed, not in their definition. However,
+  // we want the ADL definition to hold the header name, so we append the name from the
+  // reference to the map. If the same header object is ref'ed with two different names,
+  // that should create two different ADL headers.
+  const here = $.normalizeReference(`${refTo(header)}:${clientName}`).$ref;
 
-export async function* header(header: v3.Header, $: Context, options?: { isAnonymous?: boolean }): AsyncGenerator<Header> {
-  const { api, visitor } = $;
-  const name = nameOf(header);
+  const headerRef = $.visitor.references.header.get(here);
+  if (headerRef) {
+    return headerRef;
+  }
 
-  // these are in the OAI schema, but should not be in headers - freakout if they are used
-  header.explode && $.error('header definitions must not contain property \'explode\'', header.explode);
-  header.required && $.warn('header definitions should not contain property \'required\'', header.required);
+  const impl = async () => {
+    if (isReference(header)) {
+      let headerRef = $.visitor.references.header.get($.normalizeReference(`${header.$ref}:${clientName}`).$ref);
 
-  // get the schema for the header 
-  const typeref = await processSchema(header.schema, $, { isAnonymous: true });
+      // have we already got a reference for the target?
+      if (!headerRef) {
+        // nope, not handled yet.
+        const resolvedReference = await $.resolveReference(header.$ref);
+        headerRef = await processHeader(resolvedReference.node, resolvedReference.context, clientName);
+      }
 
-  // create the http header object and track it. 
-  const httpHeader = new Header({
-    // maintain the key
-    name,
-    // use the schema
-    typeRef: typeref,
-    // set a specific value 
-    description: header.description,
-    // set the style value
-    style: header.style,
-  });
+      return headerRef;
+    }
 
-  // preserve data that we're not using
-  httpHeader.addToAttic('example', header.example);
+    // these are in the OAI schema, but should not be in headers - freakout if they are used
+    header.explode && $.error('header definitions must not contain property \'explode\'', header.explode);
+    header.required && $.warn('header definitions should not contain property \'required\'', header.required);
+    
+    // style can only be simple
+    header.style != undefined && header.style != 'simple' && $.error('header style must be \'simple\'', header);
 
-  yield httpHeader;
+    // get the schema for the header 
+    const schema = await processSchema(header.schema, $, { isAnonymous: true });
+    const headerType = ts.createTypeReferenceNode(
+      'Header', [
+        schema.declaration.node,
+        ts.createLiteralTypeNode(ts.createStringLiteral(clientName))
+      ]);
+
+    let headerRef: HeaderTypeReference = {
+      declaration: new TypeSyntax(headerType),
+      requiredReferences: schema.requiredReferences,
+    };
+
+    const name = options?.isAnonymous ? anonymous('header') : nameOf(header);
+    if (!options?.isAnonymous) {
+      headerRef = createTypeAlias($.api, name, headerRef, { summary: header.description });
+    }
+
+    return headerRef;
+  };
+
+
+  const result = await impl();
+  $.visitor.references.header.set(here, result);
+  return result;
 }

--- a/adl/core/serialization/openapi/v3/request-body.ts
+++ b/adl/core/serialization/openapi/v3/request-body.ts
@@ -4,6 +4,7 @@ import { anonymous, nameOf } from '@azure-tools/sourcemap';
 import { Request } from '../../../model/http/request';
 import { processSchema } from './schema';
 import { Context } from './serializer';
+import { TypeSyntax } from '../../../support/codegen';
 
 export async function* requestBody(requestBody: v3.RequestBody, $: Context, options?: { isAnonymous?: boolean }): AsyncGenerator<Request> {
   // a single request body gets turned into multiple requests with the same name 
@@ -14,7 +15,7 @@ export async function* requestBody(requestBody: v3.RequestBody, $: Context, opti
 
   for (const [mediaType, type] of items(requestBody.content)) {
     
-    const typeref = type.schema ? await processSchema(type.schema, $, {isAnonymous: true}) : { declaration: 'dunno', requiredReferences:[]};
+    const typeref = type.schema ? await processSchema(type.schema, $, {isAnonymous: true}) : { declaration: new TypeSyntax('dunno'), requiredReferences:[]};
 
     const request = new Request(bodyName, mediaType, typeref, {
       description: requestBody.description,

--- a/adl/core/support/doc-tag.ts
+++ b/adl/core/support/doc-tag.ts
@@ -95,7 +95,7 @@ export interface Documentation {
   extensible?: boolean;
 }
 
-export function createDocs(documentationIntializer?: Documentation, additionalTags?: Array<JSDocTagStructure>): Array<JSDocStructure> {
+export function createDocs(documentationIntializer?: Documentation, additionalTags?: Array<JSDocTagStructure>): Array<JSDocStructure> | undefined {
   if( documentationIntializer) {
     const tags = new Array<JSDocTagStructure>();
     if (documentationIntializer.extensible) {
@@ -142,12 +142,15 @@ export function createDocs(documentationIntializer?: Documentation, additionalTa
     if (additionalTags) {
       tags.push(...additionalTags);
     }
-  
-    return [{
-      kind: StructureKind.JSDoc,
-      description: documentationIntializer.summary || (tags.length< 2?  '\n': ''),
-      tags
-    }];
+
+    if (documentationIntializer.summary || tags.length > 0) {
+      return [{
+        kind: StructureKind.JSDoc,
+        description: documentationIntializer.summary || (tags.length < 2 ? '\n' : ''),
+        tags
+      }];
+    }
   }
-  return [];
+
+  return undefined;
 }

--- a/adl/core/support/typescript.ts
+++ b/adl/core/support/typescript.ts
@@ -133,7 +133,7 @@ export function createImportFor(name: string, sourceFile: SourceFile, relativeTo
 
 export function addImportsTo(sourceFile: SourceFile,typeReference: TypeReference ) {
   if (typeReference.sourceFile && sourceFile !== typeReference.sourceFile ) {
-    const typeName = typeReference.declaration;
+    const typeName = typeReference.declaration.text;
 
     const importDecls = sourceFile.getImportDeclarations();
     let found = false;

--- a/adl/core/support/visitor.ts
+++ b/adl/core/support/visitor.ts
@@ -8,7 +8,7 @@ import { parse } from 'yaml';
 import { Alias } from '../model/alias';
 import { ApiModel } from '../model/api-model';
 import { Element } from '../model/element';
-import { ParameterReference, TypeReference } from '../model/schema/type';
+import { HeaderTypeReference, ParameterTypeReference, SchemaTypeReference } from '../model/schema/type';
 import { Host } from './file-system';
 import { Stopwatch } from './stopwatch';
 
@@ -54,9 +54,9 @@ class RefMap {
 }
 
 export class ReferenceMap {
-  schema = new Map<JsonPointer, TypeReference>();
-  parameter = new Map<JsonPointer, ParameterReference> ();
-  
+  schema = new Map<JsonPointer, SchemaTypeReference>();
+  parameter = new Map<JsonPointer, ParameterTypeReference> ();
+  header = new Map<JsonPointer, HeaderTypeReference> ();
 }
 
 export class Visitor<TSourceModel extends OAIModel> {

--- a/adl/core/test/manipulation.ts
+++ b/adl/core/test/manipulation.ts
@@ -13,7 +13,7 @@ import { EnumValue } from '../model/schema/enum';
     for (let i = 0; i < actual.length; i++) {
       assert.strictEqual(actual[i].name, expected[i].name);
       assert.strictEqual(actual[i].value, expected[i].value);
-      assert.strictEqual(actual[i].description, expected[i].description);
+      assert.strictEqual(actual[i].summary, expected[i].summary);
     }
   }
 

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AccessIdName.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AccessIdName.ts
@@ -5,8 +5,5 @@
  * @since 2019-12-01
  */
 export enum AccessIdName {
-    /**
-     *
-     */
     access = 'access'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AlwaysLog.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AlwaysLog.ts
@@ -5,9 +5,6 @@
  * @since 2019-12-01
  */
 export enum AlwaysLog {
-    /**
-     *
-     * @description Always log all erroneous request regardless of sampling settings.
-     */
+    /** Always log all erroneous request regardless of sampling settings. */
     allErrors = 'allErrors'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ApiType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ApiType.ts
@@ -6,12 +6,6 @@
  * @since 2019-12-01
  */
 export enum ApiType {
-    /**
-     *
-     */
     http = 'http',
-    /**
-     *
-     */
     soap = 'soap'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AppType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AppType.ts
@@ -5,9 +5,6 @@
  * @since 2019-12-01
  */
 export enum AppType {
-    /**
-     *
-     * @description User create request was sent by new developer portal.
-     */
+    /** User create request was sent by new developer portal. */
     developerPortal = 'developerPortal'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AsyncOperationStatus.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AsyncOperationStatus.ts
@@ -4,20 +4,8 @@
  * @since 2019-12-01
  */
 export enum AsyncOperationStatus {
-    /**
-     *
-     */
     Started = 'Started',
-    /**
-     *
-     */
     InProgress = 'InProgress',
-    /**
-     *
-     */
     Succeeded = 'Succeeded',
-    /**
-     *
-     */
     Failed = 'Failed'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AuthorizationMethod.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/AuthorizationMethod.ts
@@ -4,36 +4,12 @@
  * @since 2019-12-01
  */
 export enum AuthorizationMethod {
-    /**
-     *
-     */
     HEAD = 'HEAD',
-    /**
-     *
-     */
     OPTIONS = 'OPTIONS',
-    /**
-     *
-     */
     TRACE = 'TRACE',
-    /**
-     *
-     */
     GET = 'GET',
-    /**
-     *
-     */
     POST = 'POST',
-    /**
-     *
-     */
     PUT = 'PUT',
-    /**
-     *
-     */
     PATCH = 'PATCH',
-    /**
-     *
-     */
     DELETE = 'DELETE'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/BackendProtocol.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/BackendProtocol.ts
@@ -5,14 +5,8 @@
  * @since 2019-12-01
  */
 export enum BackendProtocol {
-    /**
-     *
-     * @description The Backend is a RESTful service.
-     */
+    /** The Backend is a RESTful service. */
     http = 'http',
-    /**
-     *
-     * @description The Backend is a SOAP service.
-     */
+    /** The Backend is a SOAP service. */
     soap = 'soap'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/BearerTokenSendingMethod.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/BearerTokenSendingMethod.ts
@@ -4,12 +4,6 @@
  * @since 2019-12-01
  */
 export enum BearerTokenSendingMethod {
-    /**
-     *
-     */
     authorizationHeader = 'authorizationHeader',
-    /**
-     *
-     */
     query = 'query'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ClientAuthenticationMethod.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ClientAuthenticationMethod.ts
@@ -4,14 +4,8 @@
  * @since 2019-12-01
  */
 export enum ClientAuthenticationMethod {
-    /**
-     *
-     * @description Basic Client Authentication method.
-     */
+    /** Basic Client Authentication method. */
     Basic = 'Basic',
-    /**
-     *
-     * @description Body based Authentication method.
-     */
+    /** Body based Authentication method. */
     Body = 'Body'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/Confirmation.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/Confirmation.ts
@@ -5,14 +5,8 @@
  * @since 2019-12-01
  */
 export enum Confirmation {
-    /**
-     *
-     * @description Send an e-mail to the user confirming they have successfully signed up.
-     */
+    /** Send an e-mail to the user confirming they have successfully signed up. */
     signup = 'signup',
-    /**
-     *
-     * @description Send an e-mail inviting the user to sign-up and complete registration.
-     */
+    /** Send an e-mail inviting the user to sign-up and complete registration. */
     invite = 'invite'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ContentFormat.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ContentFormat.ts
@@ -6,54 +6,24 @@
  * @since 2019-12-01
  */
 export enum ContentFormat {
-    /**
-     *
-     * @description The contents are inline and Content type is a WADL document.
-     */
+    /** The contents are inline and Content type is a WADL document. */
     'wadl-xml' = 'wadl-xml',
-    /**
-     *
-     * @description The WADL document is hosted on a publicly accessible internet address.
-     */
+    /** The WADL document is hosted on a publicly accessible internet address. */
     'wadl-link-json' = 'wadl-link-json',
-    /**
-     *
-     * @description The contents are inline and Content Type is a OpenApi 2.0 Document.
-     */
+    /** The contents are inline and Content Type is a OpenApi 2.0 Document. */
     'swagger-json' = 'swagger-json',
-    /**
-     *
-     * @description The Open Api 2.0 document is hosted on a publicly accessible internet address.
-     */
+    /** The Open Api 2.0 document is hosted on a publicly accessible internet address. */
     'swagger-link-json' = 'swagger-link-json',
-    /**
-     *
-     * @description The contents are inline and the document is a WSDL/Soap document.
-     */
+    /** The contents are inline and the document is a WSDL/Soap document. */
     wsdl = 'wsdl',
-    /**
-     *
-     * @description The WSDL document is hosted on a publicly accessible internet address.
-     */
+    /** The WSDL document is hosted on a publicly accessible internet address. */
     'wsdl-link' = 'wsdl-link',
-    /**
-     *
-     * @description The contents are inline and Content Type is a OpenApi 3.0 Document in YAML format.
-     */
+    /** The contents are inline and Content Type is a OpenApi 3.0 Document in YAML format. */
     openapi = 'openapi',
-    /**
-     *
-     * @description The contents are inline and Content Type is a OpenApi 3.0 Document in JSON format.
-     */
+    /** The contents are inline and Content Type is a OpenApi 3.0 Document in JSON format. */
     'openapi+json' = 'openapi+json',
-    /**
-     *
-     * @description The Open Api 3.0 document is hosted on a publicly accessible internet address.
-     */
+    /** The Open Api 3.0 document is hosted on a publicly accessible internet address. */
     'openapi-link' = 'openapi-link',
-    /**
-     *
-     * @description The Open Api 3.0 Json document is hosted on a publicly accessible internet address.
-     */
+    /** The Open Api 3.0 Json document is hosted on a publicly accessible internet address. */
     'openapi+json-link' = 'openapi+json-link'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ExportResultFormat.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ExportResultFormat.ts
@@ -6,24 +6,12 @@
  * @since 2019-12-01
  */
 export enum ExportResultFormat {
-    /**
-     *
-     * @description The Api Definition is exported in OpenApi Specification 2.0 format to the Storage Blob.
-     */
+    /** The Api Definition is exported in OpenApi Specification 2.0 format to the Storage Blob. */
     Swagger = 'swagger-link-json',
-    /**
-     *
-     * @description The Api Definition is exported in WSDL Schema to Storage Blob. This is only supported for APIs of Type `soap`
-     */
+    /** The Api Definition is exported in WSDL Schema to Storage Blob. This is only supported for APIs of Type `soap` */
     Wsdl = 'wsdl-link+xml',
-    /**
-     *
-     * @description Export the Api Definition in WADL Schema to Storage Blob.
-     */
+    /** Export the Api Definition in WADL Schema to Storage Blob. */
     Wadl = 'wadl-link-json',
-    /**
-     *
-     * @description Export the Api Definition in OpenApi Specification 3.0 to Storage Blob.
-     */
+    /** Export the Api Definition in OpenApi Specification 3.0 to Storage Blob. */
     OpenApi = 'openapi-link'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/GrantType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/GrantType.ts
@@ -4,24 +4,12 @@
  * @since 2019-12-01
  */
 export enum GrantType {
-    /**
-     *
-     * @description Authorization Code Grant flow as described https://tools.ietf.org/html/rfc6749#section-4.1.
-     */
+    /** Authorization Code Grant flow as described https://tools.ietf.org/html/rfc6749#section-4.1. */
     authorizationCode = 'authorizationCode',
-    /**
-     *
-     * @description Implicit Code Grant flow as described https://tools.ietf.org/html/rfc6749#section-4.2.
-     */
+    /** Implicit Code Grant flow as described https://tools.ietf.org/html/rfc6749#section-4.2. */
     implicit = 'implicit',
-    /**
-     *
-     * @description Resource Owner Password Grant flow as described https://tools.ietf.org/html/rfc6749#section-4.3.
-     */
+    /** Resource Owner Password Grant flow as described https://tools.ietf.org/html/rfc6749#section-4.3. */
     resourceOwnerPassword = 'resourceOwnerPassword',
-    /**
-     *
-     * @description Client Credentials Grant flow as described https://tools.ietf.org/html/rfc6749#section-4.4.
-     */
+    /** Client Credentials Grant flow as described https://tools.ietf.org/html/rfc6749#section-4.4. */
     clientCredentials = 'clientCredentials'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/GroupType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/GroupType.ts
@@ -4,16 +4,7 @@
  * @since 2019-12-01
  */
 export enum GroupType {
-    /**
-     *
-     */
     custom = 'custom',
-    /**
-     *
-     */
     system = 'system',
-    /**
-     *
-     */
     external = 'external'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/HttpCorrelationProtocol.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/HttpCorrelationProtocol.ts
@@ -5,19 +5,10 @@
  * @since 2019-12-01
  */
 export enum HttpCorrelationProtocol {
-    /**
-     *
-     * @description Do not read and inject correlation headers.
-     */
+    /** Do not read and inject correlation headers. */
     None = 'None',
-    /**
-     *
-     * @description Inject Request-Id and Request-Context headers with request correlation data. See https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/HttpCorrelationProtocol.md.
-     */
+    /** Inject Request-Id and Request-Context headers with request correlation data. See https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/HttpCorrelationProtocol.md. */
     Legacy = 'Legacy',
-    /**
-     *
-     * @description Inject Trace Context headers. See https://w3c.github.io/trace-context.
-     */
+    /** Inject Trace Context headers. See https://w3c.github.io/trace-context. */
     W3C = 'W3C'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/IdentityProviderType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/IdentityProviderType.ts
@@ -5,34 +5,16 @@
  * @since 2019-12-01
  */
 export enum IdentityProviderType {
-    /**
-     *
-     * @description Facebook as Identity provider.
-     */
+    /** Facebook as Identity provider. */
     facebook = 'facebook',
-    /**
-     *
-     * @description Google as Identity provider.
-     */
+    /** Google as Identity provider. */
     google = 'google',
-    /**
-     *
-     * @description Microsoft Live as Identity provider.
-     */
+    /** Microsoft Live as Identity provider. */
     microsoft = 'microsoft',
-    /**
-     *
-     * @description Twitter as Identity provider.
-     */
+    /** Twitter as Identity provider. */
     twitter = 'twitter',
-    /**
-     *
-     * @description Azure Active Directory as Identity provider.
-     */
+    /** Azure Active Directory as Identity provider. */
     aad = 'aad',
-    /**
-     *
-     * @description Azure Active Directory B2C as Identity provider.
-     */
+    /** Azure Active Directory B2C as Identity provider. */
     aadB2C = 'aadB2C'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/KeyType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/KeyType.ts
@@ -4,12 +4,6 @@
  * @since 2019-12-01
  */
 export enum KeyType {
-    /**
-     *
-     */
     primary = 'primary',
-    /**
-     *
-     */
     secondary = 'secondary'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/LoggerType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/LoggerType.ts
@@ -5,14 +5,8 @@
  * @since 2019-12-01
  */
 export enum LoggerType {
-    /**
-     *
-     * @description Azure Event Hub as log destination.
-     */
+    /** Azure Event Hub as log destination. */
     azureEventHub = 'azureEventHub',
-    /**
-     *
-     * @description Azure Application Insights as log destination.
-     */
+    /** Azure Application Insights as log destination. */
     applicationInsights = 'applicationInsights'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/NotificationName.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/NotificationName.ts
@@ -5,39 +5,18 @@
  * @since 2019-12-01
  */
 export enum NotificationName {
-    /**
-     *
-     * @description The following email recipients and users will receive email notifications about subscription requests for API products requiring approval.
-     */
+    /** The following email recipients and users will receive email notifications about subscription requests for API products requiring approval. */
     RequestPublisherNotificationMessage = 'RequestPublisherNotificationMessage',
-    /**
-     *
-     * @description The following email recipients and users will receive email notifications about new API product subscriptions.
-     */
+    /** The following email recipients and users will receive email notifications about new API product subscriptions. */
     PurchasePublisherNotificationMessage = 'PurchasePublisherNotificationMessage',
-    /**
-     *
-     * @description The following email recipients and users will receive email notifications when new applications are submitted to the application gallery.
-     */
+    /** The following email recipients and users will receive email notifications when new applications are submitted to the application gallery. */
     NewApplicationNotificationMessage = 'NewApplicationNotificationMessage',
-    /**
-     *
-     * @description The following recipients will receive blind carbon copies of all emails sent to developers.
-     */
+    /** The following recipients will receive blind carbon copies of all emails sent to developers. */
     BCC = 'BCC',
-    /**
-     *
-     * @description The following email recipients and users will receive email notifications when a new issue or comment is submitted on the developer portal.
-     */
+    /** The following email recipients and users will receive email notifications when a new issue or comment is submitted on the developer portal. */
     NewIssuePublisherNotificationMessage = 'NewIssuePublisherNotificationMessage',
-    /**
-     *
-     * @description The following email recipients and users will receive email notifications when developer closes his account.
-     */
+    /** The following email recipients and users will receive email notifications when developer closes his account. */
     AccountClosedPublisher = 'AccountClosedPublisher',
-    /**
-     *
-     * @description The following email recipients and users will receive email notifications when subscription usage gets close to usage quota.
-     */
+    /** The following email recipients and users will receive email notifications when subscription usage gets close to usage quota. */
     QuotaLimitApproachingPublisherNotificationMessage = 'QuotaLimitApproachingPublisherNotificationMessage'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/PolicyContentFormat.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/PolicyContentFormat.ts
@@ -5,24 +5,12 @@
  * @since 2019-12-01
  */
 export enum PolicyContentFormat {
-    /**
-     *
-     * @description The contents are inline and Content type is an XML document.
-     */
+    /** The contents are inline and Content type is an XML document. */
     xml = 'xml',
-    /**
-     *
-     * @description The policy XML document is hosted on a http endpoint accessible from the API Management service.
-     */
+    /** The policy XML document is hosted on a http endpoint accessible from the API Management service. */
     'xml-link' = 'xml-link',
-    /**
-     *
-     * @description The contents are inline and Content type is a non XML encoded policy document.
-     */
+    /** The contents are inline and Content type is a non XML encoded policy document. */
     rawxml = 'rawxml',
-    /**
-     *
-     * @description The policy document is not Xml encoded and is hosted on a http endpoint accessible from the API Management service.
-     */
+    /** The policy document is not Xml encoded and is hosted on a http endpoint accessible from the API Management service. */
     'rawxml-link' = 'rawxml-link'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/PolicyExportFormat.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/PolicyExportFormat.ts
@@ -5,14 +5,8 @@
  * @since 2019-12-01
  */
 export enum PolicyExportFormat {
-    /**
-     *
-     * @description The contents are inline and Content type is an XML document.
-     */
+    /** The contents are inline and Content type is an XML document. */
     xml = 'xml',
-    /**
-     *
-     * @description The contents are inline and Content type is a non XML encoded policy document.
-     */
+    /** The contents are inline and Content type is a non XML encoded policy document. */
     rawxml = 'rawxml'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/PolicyIdName.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/PolicyIdName.ts
@@ -5,8 +5,5 @@
  * @since 2019-12-01
  */
 export enum PolicyIdName {
-    /**
-     *
-     */
     policy = 'policy'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ProductState.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ProductState.ts
@@ -4,12 +4,6 @@
  * @since 2019-12-01
  */
 export enum ProductState {
-    /**
-     *
-     */
     notPublished = 'notPublished',
-    /**
-     *
-     */
     published = 'published'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/Protocol.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/Protocol.ts
@@ -4,12 +4,6 @@
  * @since 2019-12-01
  */
 export enum Protocol {
-    /**
-     *
-     */
     http = 'http',
-    /**
-     *
-     */
     https = 'https'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ProvisioningState.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/ProvisioningState.ts
@@ -4,8 +4,5 @@
  * @since 2019-12-01
  */
 export enum ProvisioningState {
-    /**
-     *
-     */
     created = 'created'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/SamplingType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/SamplingType.ts
@@ -5,9 +5,6 @@
  * @since 2019-12-01
  */
 export enum SamplingType {
-    /**
-     *
-     * @description Fixed-rate sampling.
-     */
+    /** Fixed-rate sampling. */
     fixed = 'fixed'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/SoapApiType.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/SoapApiType.ts
@@ -8,14 +8,8 @@
  * @since 2019-12-01
  */
 export enum SoapApiType {
-    /**
-     *
-     * @description Imports a SOAP API having a RESTful front end.
-     */
+    /** Imports a SOAP API having a RESTful front end. */
     SoapToRest = 'http',
-    /**
-     *
-     * @description Imports the Soap API having a SOAP front end.
-     */
+    /** Imports the Soap API having a SOAP front end. */
     SoapPassThrough = 'soap'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/State.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/State.ts
@@ -5,29 +5,14 @@
  * @since 2019-12-01
  */
 export enum State {
-    /**
-     *
-     * @description The issue is proposed.
-     */
+    /** The issue is proposed. */
     proposed = 'proposed',
-    /**
-     *
-     * @description The issue is opened.
-     */
+    /** The issue is opened. */
     open = 'open',
-    /**
-     *
-     * @description The issue was removed.
-     */
+    /** The issue was removed. */
     removed = 'removed',
-    /**
-     *
-     * @description The issue is now resolved.
-     */
+    /** The issue is now resolved. */
     resolved = 'resolved',
-    /**
-     *
-     * @description The issue was closed.
-     */
+    /** The issue was closed. */
     closed = 'closed'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/SubscriptionState.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/SubscriptionState.ts
@@ -4,28 +4,10 @@
  * @since 2019-12-01
  */
 export enum SubscriptionState {
-    /**
-     *
-     */
     suspended = 'suspended',
-    /**
-     *
-     */
     active = 'active',
-    /**
-     *
-     */
     expired = 'expired',
-    /**
-     *
-     */
     submitted = 'submitted',
-    /**
-     *
-     */
     rejected = 'rejected',
-    /**
-     *
-     */
     cancelled = 'cancelled'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/TemplateName.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/TemplateName.ts
@@ -5,60 +5,18 @@
  * @since 2019-12-01
  */
 export enum TemplateName {
-    /**
-     *
-     */
     applicationApprovedNotificationMessage = 'applicationApprovedNotificationMessage',
-    /**
-     *
-     */
     accountClosedDeveloper = 'accountClosedDeveloper',
-    /**
-     *
-     */
     quotaLimitApproachingDeveloperNotificationMessage = 'quotaLimitApproachingDeveloperNotificationMessage',
-    /**
-     *
-     */
     newDeveloperNotificationMessage = 'newDeveloperNotificationMessage',
-    /**
-     *
-     */
     emailChangeIdentityDefault = 'emailChangeIdentityDefault',
-    /**
-     *
-     */
     inviteUserNotificationMessage = 'inviteUserNotificationMessage',
-    /**
-     *
-     */
     newCommentNotificationMessage = 'newCommentNotificationMessage',
-    /**
-     *
-     */
     confirmSignUpIdentityDefault = 'confirmSignUpIdentityDefault',
-    /**
-     *
-     */
     newIssueNotificationMessage = 'newIssueNotificationMessage',
-    /**
-     *
-     */
     purchaseDeveloperNotificationMessage = 'purchaseDeveloperNotificationMessage',
-    /**
-     *
-     */
     passwordResetIdentityDefault = 'passwordResetIdentityDefault',
-    /**
-     *
-     */
     passwordResetByAdminNotificationMessage = 'passwordResetByAdminNotificationMessage',
-    /**
-     *
-     */
     rejectDeveloperNotificationMessage = 'rejectDeveloperNotificationMessage',
-    /**
-     *
-     */
     requestDeveloperNotificationMessage = 'requestDeveloperNotificationMessage'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/UserState.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/UserState.ts
@@ -5,24 +5,12 @@
  * @since 2019-12-01
  */
 export enum UserState {
-    /**
-     *
-     * @description User state is active.
-     */
+    /** User state is active. */
     active = 'active',
-    /**
-     *
-     * @description User is blocked. Blocked users cannot authenticate at developer portal or call API.
-     */
+    /** User is blocked. Blocked users cannot authenticate at developer portal or call API. */
     blocked = 'blocked',
-    /**
-     *
-     * @description User account is pending. Requires identity confirmation before it can be made active.
-     */
+    /** User account is pending. Requires identity confirmation before it can be made active. */
     pending = 'pending',
-    /**
-     *
-     * @description User account is closed. All identities and related entities are removed.
-     */
+    /** User account is closed. All identities and related entities are removed. */
     deleted = 'deleted'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/Verbosity.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/Verbosity.ts
@@ -5,19 +5,10 @@
  * @since 2019-12-01
  */
 export enum Verbosity {
-    /**
-     *
-     * @description All the traces emitted by trace policies will be sent to the logger attached to this diagnostic instance.
-     */
+    /** All the traces emitted by trace policies will be sent to the logger attached to this diagnostic instance. */
     verbose = 'verbose',
-    /**
-     *
-     * @description Traces with 'severity' set to 'information' and 'error' will be sent to the logger attached to this diagnostic instance.
-     */
+    /** Traces with 'severity' set to 'information' and 'error' will be sent to the logger attached to this diagnostic instance. */
     information = 'information',
-    /**
-     *
-     * @description Only traces with 'severity' set to 'error' will be sent to the logger attached to this diagnostic instance.
-     */
+    /** Only traces with 'severity' set to 'error' will be sent to the logger attached to this diagnostic instance. */
     error = 'error'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/bearerTokenSendingMethods.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/bearerTokenSendingMethods.ts
@@ -5,14 +5,8 @@
  * @since 2019-12-01
  */
 export enum bearerTokenSendingMethods {
-    /**
-     *
-     * @description Access token will be transmitted in the Authorization header using Bearer schema
-     */
+    /** Access token will be transmitted in the Authorization header using Bearer schema */
     authorizationHeader = 'authorizationHeader',
-    /**
-     *
-     * @description Access token will be transmitted as query parameters.
-     */
+    /** Access token will be transmitted as query parameters. */
     query = 'query'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/configurationIdName.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/configurationIdName.ts
@@ -5,8 +5,5 @@
  * @since 2019-12-01
  */
 export enum configurationIdName {
-    /**
-     *
-     */
     configuration = 'configuration'
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/enums/versioningScheme.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/enums/versioningScheme.ts
@@ -5,19 +5,10 @@
  * @since 2019-12-01
  */
 export enum versioningScheme {
-    /**
-     *
-     * @description The API Version is passed in a path segment.
-     */
+    /** The API Version is passed in a path segment. */
     Segment = 'Segment',
-    /**
-     *
-     * @description The API Version is passed in a query parameter.
-     */
+    /** The API Version is passed in a query parameter. */
     Query = 'Query',
-    /**
-     *
-     * @description The API Version is passed in a HTTP header.
-     */
+    /** The API Version is passed in a HTTP header. */
     Header = 'Header'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/AccessPolicyUpdateKind.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/AccessPolicyUpdateKind.ts
@@ -4,16 +4,7 @@
  * @since 2019-09-01
  */
 export enum AccessPolicyUpdateKind {
-    /**
-     *
-     */
     add = 'add',
-    /**
-     *
-     */
     replace = 'replace',
-    /**
-     *
-     */
     remove = 'remove'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/CertificatePermissions.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/CertificatePermissions.ts
@@ -4,68 +4,20 @@
  * @since 2019-09-01
  */
 export enum CertificatePermissions {
-    /**
-     *
-     */
     get = 'get',
-    /**
-     *
-     */
     list = 'list',
-    /**
-     *
-     */
     delete = 'delete',
-    /**
-     *
-     */
     create = 'create',
-    /**
-     *
-     */
     import = 'import',
-    /**
-     *
-     */
     update = 'update',
-    /**
-     *
-     */
     managecontacts = 'managecontacts',
-    /**
-     *
-     */
     getissuers = 'getissuers',
-    /**
-     *
-     */
     listissuers = 'listissuers',
-    /**
-     *
-     */
     setissuers = 'setissuers',
-    /**
-     *
-     */
     deleteissuers = 'deleteissuers',
-    /**
-     *
-     */
     manageissuers = 'manageissuers',
-    /**
-     *
-     */
     recover = 'recover',
-    /**
-     *
-     */
     purge = 'purge',
-    /**
-     *
-     */
     backup = 'backup',
-    /**
-     *
-     */
     restore = 'restore'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/CreateMode.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/CreateMode.ts
@@ -4,12 +4,6 @@
  * @since 2019-09-01
  */
 export enum CreateMode {
-    /**
-     *
-     */
     recover = 'recover',
-    /**
-     *
-     */
     default = 'default'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/KeyPermissions.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/KeyPermissions.ts
@@ -4,68 +4,20 @@
  * @since 2019-09-01
  */
 export enum KeyPermissions {
-    /**
-     *
-     */
     encrypt = 'encrypt',
-    /**
-     *
-     */
     decrypt = 'decrypt',
-    /**
-     *
-     */
     wrapKey = 'wrapKey',
-    /**
-     *
-     */
     unwrapKey = 'unwrapKey',
-    /**
-     *
-     */
     sign = 'sign',
-    /**
-     *
-     */
     verify = 'verify',
-    /**
-     *
-     */
     get = 'get',
-    /**
-     *
-     */
     list = 'list',
-    /**
-     *
-     */
     create = 'create',
-    /**
-     *
-     */
     update = 'update',
-    /**
-     *
-     */
     import = 'import',
-    /**
-     *
-     */
     delete = 'delete',
-    /**
-     *
-     */
     backup = 'backup',
-    /**
-     *
-     */
     restore = 'restore',
-    /**
-     *
-     */
     recover = 'recover',
-    /**
-     *
-     */
     purge = 'purge'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/NetworkRuleAction.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/NetworkRuleAction.ts
@@ -5,12 +5,6 @@
  * @since 2019-09-01
  */
 export enum NetworkRuleAction {
-    /**
-     *
-     */
     Allow = 'Allow',
-    /**
-     *
-     */
     Deny = 'Deny'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/NetworkRuleBypassOptions.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/NetworkRuleBypassOptions.ts
@@ -5,12 +5,6 @@
  * @since 2019-09-01
  */
 export enum NetworkRuleBypassOptions {
-    /**
-     *
-     */
     AzureServices = 'AzureServices',
-    /**
-     *
-     */
     None = 'None'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/PrivateEndpointConnectionProvisioningState.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/PrivateEndpointConnectionProvisioningState.ts
@@ -5,28 +5,10 @@
  * @since 2019-09-01
  */
 export enum PrivateEndpointConnectionProvisioningState {
-    /**
-     *
-     */
     Succeeded = 'Succeeded',
-    /**
-     *
-     */
     Creating = 'Creating',
-    /**
-     *
-     */
     Updating = 'Updating',
-    /**
-     *
-     */
     Deleting = 'Deleting',
-    /**
-     *
-     */
     Failed = 'Failed',
-    /**
-     *
-     */
     Disconnected = 'Disconnected'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/PrivateEndpointServiceConnectionStatus.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/PrivateEndpointServiceConnectionStatus.ts
@@ -5,20 +5,8 @@
  * @since 2019-09-01
  */
 export enum PrivateEndpointServiceConnectionStatus {
-    /**
-     *
-     */
     Pending = 'Pending',
-    /**
-     *
-     */
     Approved = 'Approved',
-    /**
-     *
-     */
     Rejected = 'Rejected',
-    /**
-     *
-     */
     Disconnected = 'Disconnected'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/Reason.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/Reason.ts
@@ -4,12 +4,6 @@
  * @since 2019-09-01
  */
 export enum Reason {
-    /**
-     *
-     */
     AccountNameInvalid = 'AccountNameInvalid',
-    /**
-     *
-     */
     AlreadyExists = 'AlreadyExists'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/SecretPermissions.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/SecretPermissions.ts
@@ -4,36 +4,12 @@
  * @since 2019-09-01
  */
 export enum SecretPermissions {
-    /**
-     *
-     */
     get = 'get',
-    /**
-     *
-     */
     list = 'list',
-    /**
-     *
-     */
     set = 'set',
-    /**
-     *
-     */
     delete = 'delete',
-    /**
-     *
-     */
     backup = 'backup',
-    /**
-     *
-     */
     restore = 'restore',
-    /**
-     *
-     */
     recover = 'recover',
-    /**
-     *
-     */
     purge = 'purge'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/SkuFamily.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/SkuFamily.ts
@@ -5,8 +5,5 @@
  * @since 2019-09-01
  */
 export enum SkuFamily {
-    /**
-     *
-     */
     A = 'A'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/SkuName.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/SkuName.ts
@@ -4,12 +4,6 @@
  * @since 2019-09-01
  */
 export enum SkuName {
-    /**
-     *
-     */
     standard = 'standard',
-    /**
-     *
-     */
     premium = 'premium'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/StoragePermissions.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/StoragePermissions.ts
@@ -4,60 +4,18 @@
  * @since 2019-09-01
  */
 export enum StoragePermissions {
-    /**
-     *
-     */
     get = 'get',
-    /**
-     *
-     */
     list = 'list',
-    /**
-     *
-     */
     delete = 'delete',
-    /**
-     *
-     */
     set = 'set',
-    /**
-     *
-     */
     update = 'update',
-    /**
-     *
-     */
     regeneratekey = 'regeneratekey',
-    /**
-     *
-     */
     recover = 'recover',
-    /**
-     *
-     */
     purge = 'purge',
-    /**
-     *
-     */
     backup = 'backup',
-    /**
-     *
-     */
     restore = 'restore',
-    /**
-     *
-     */
     setsas = 'setsas',
-    /**
-     *
-     */
     listsas = 'listsas',
-    /**
-     *
-     */
     getsas = 'getsas',
-    /**
-     *
-     */
     deletesas = 'deletesas'
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/Type.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/enums/Type.ts
@@ -4,8 +4,5 @@
  * @since 2019-09-01
  */
 export enum Type {
-    /**
-     *
-     */
     'Microsoft.KeyVault/vaults' = 'Microsoft.KeyVault/vaults'
 }

--- a/adl/test/scenarios/v3/single/output/ablyio/aliases/ErrorCode.ts
+++ b/adl/test/scenarios/v3/single/output/ablyio/aliases/ErrorCode.ts
@@ -1,0 +1,3 @@
+
+/** The error code. */
+export type ErrorCode = Header<int64, "x-ably-errorcode">;

--- a/adl/test/scenarios/v3/single/output/ablyio/aliases/ErrorMessage.ts
+++ b/adl/test/scenarios/v3/single/output/ablyio/aliases/ErrorMessage.ts
@@ -1,0 +1,3 @@
+
+/** The error message. */
+export type ErrorMessage = Header<string, "x-ably-errormessage">;

--- a/adl/test/scenarios/v3/single/output/ablyio/aliases/Link.ts
+++ b/adl/test/scenarios/v3/single/output/ablyio/aliases/Link.ts
@@ -1,0 +1,3 @@
+
+/** Links to related resources, in the format defined by [RFC 5988](https://tools.ietf.org/html/rfc5988#section-5). This will potentially include a link with relation type `next`, `first`, and `current`, where appropiate. */
+export type Link = Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "link">;

--- a/adl/test/scenarios/v3/single/output/ablyio/aliases/ServerId.ts
+++ b/adl/test/scenarios/v3/single/output/ablyio/aliases/ServerId.ts
@@ -1,0 +1,3 @@
+
+/** The ID for the server communicated with. */
+export type ServerId = Header<string, "x-ably-serverid">;

--- a/adl/test/scenarios/v3/single/output/ablyio/operations/Service.ts
+++ b/adl/test/scenarios/v3/single/output/ablyio/operations/Service.ts
@@ -18,22 +18,22 @@ export interface Service {
      */
     getMetadataOfAllChannels(X_Ably_Version?: Header<string, 'X-Ably-Version'>, format?: Query<"json" | "jsonp" | "msgpack" | "html">, limit?: Query<int64 /* todo: add defaultValue '100' */>, prefix?: Query<string>, by?: Query<"value" | "id">): [(code: "2XX", mediaType: "application/json") => {
         body: Xor<Array<ChannelDetails>, Array<string>>;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">];
+        headers: [Link];
     }, (code: "2XX", mediaType: "application/x-msgpack") => {
         body: Xor<Array<ChannelDetails>, Array<string>>;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">];
+        headers: [Link];
     }, (code: "2XX", mediaType: "text/html") => {
         body: string;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">];
+        headers: [Link];
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Get metadata of a channel
@@ -51,16 +51,16 @@ export interface Service {
      */
     getMetadataOfChannel(X_Ably_Version?: Header<string, 'X-Ably-Version'>, format?: Query<"json" | "jsonp" | "msgpack" | "html">, channel_id: string): [(code: 200, mediaType: "application/json") => {
         body: ChannelDetails;
-        headers: [Header<string, "ServerId">];
+        headers: [ServerId];
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Get message history for a channel
@@ -78,15 +78,15 @@ export interface Service {
      */
     getMessagesByChannel(X_Ably_Version?: Header<string, 'X-Ably-Version'>, format?: Query<"json" | "jsonp" | "msgpack" | "html">, channel_id: string, start?: Query<string>, limit?: Query<int64 /* todo: add defaultValue '"100"' */>, end?: Query<string /* todo: add defaultValue '"now"' */>, direction?: Query<"forwards" | "backwards">): [(code: "2XX", mediaType: "application/json") => {
         body: Array<Message>;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">, Header<string, "ServerId">];
+        headers: [Link, ServerId];
     }, (code: "2XX", mediaType: "application/x-msgpack") => {
         body: Array<Message>;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">, Header<string, "ServerId">];
+        headers: [Link, ServerId];
     }, (code: "2XX", mediaType: "text/html") => {
         body: string;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">, Header<string, "ServerId">];
+        headers: [Link, ServerId];
     }, () => {
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
         isException: true;
     }];
     /**
@@ -118,7 +118,7 @@ export interface Service {
              */
             messageId?: string;
         };
-        headers: [Header<string, "ServerId">];
+        headers: [ServerId];
     }, (code: "2XX", mediaType: "application/x-msgpack") => {
         body: {
             /**
@@ -132,7 +132,7 @@ export interface Service {
              */
             messageId?: string;
         };
-        headers: [Header<string, "ServerId">];
+        headers: [ServerId];
     }, (code: "2XX", mediaType: "text/html") => {
         body: {
             /**
@@ -146,16 +146,16 @@ export interface Service {
              */
             messageId?: string;
         };
-        headers: [Header<string, "ServerId">];
+        headers: [ServerId];
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Get presence of a channel
@@ -175,22 +175,22 @@ export interface Service {
      */
     getPresenceOfChannel(X_Ably_Version?: Header<string, 'X-Ably-Version'>, format?: Query<"json" | "jsonp" | "msgpack" | "html">, channel_id: string, clientId?: Query<string>, connectionId?: Query<string>, limit?: Query<int64 /* todo: add defaultValue '100' */>): [(code: 200, mediaType: "application/json") => {
         body: Array<PresenceMessage>;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">, Header<string, "ServerId">];
+        headers: [Link, ServerId];
     }, (code: 200, mediaType: "application/x-msgpack") => {
         body: Array<PresenceMessage>;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">, Header<string, "ServerId">];
+        headers: [Link, ServerId];
     }, (code: 200, mediaType: "text/html") => {
         body: string;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">, Header<string, "ServerId">];
+        headers: [Link, ServerId];
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Get presence history of a channel
@@ -210,22 +210,22 @@ export interface Service {
      */
     getPresenceHistoryOfChannel(X_Ably_Version?: Header<string, 'X-Ably-Version'>, format?: Query<"json" | "jsonp" | "msgpack" | "html">, channel_id: string, start?: Query<string>, limit?: Query<int64 /* todo: add defaultValue '"100"' */>, end?: Query<string /* todo: add defaultValue '"now"' */>, direction?: Query<"forwards" | "backwards">): [(code: "2XX", mediaType: "application/json") => {
         body: Array<PresenceMessage>;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">];
+        headers: [Link];
     }, (code: "2XX", mediaType: "application/x-msgpack") => {
         body: Array<PresenceMessage>;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">];
+        headers: [Link];
     }, (code: "2XX", mediaType: "text/html") => {
         body: string;
-        headers: [Header<string & RegularExpression<'(<(.*)?>; rel=\"(first|current|last)?\",)*(<(.*)?>; rel=\"(first|current|last)?\")+'>, "Link">];
+        headers: [Link];
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Request an access token
@@ -248,13 +248,13 @@ export interface Service {
         body: TokenDetails;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * List channel subscriptions
@@ -277,13 +277,13 @@ export interface Service {
         body: DeviceDetails;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Subscribe a device to a channel
@@ -366,13 +366,13 @@ export interface Service {
         clientId?: string;
     }>, 'application/x-www-form-urlencoded'>): [(code: "2XX") => {}, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Delete a registered device's update token
@@ -392,13 +392,13 @@ export interface Service {
      */
     deletePushDeviceDetails(X_Ably_Version?: Header<string, 'X-Ably-Version'>, format?: Query<"json" | "jsonp" | "msgpack" | "html">, channel?: Query<string>, deviceId?: Query<string>, clientId?: Query<string>): [(code: "2XX") => {}, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * List all channels with at least one subscribed device
@@ -423,13 +423,13 @@ export interface Service {
         body: Array<string>;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * List devices registered for receiving push notifications
@@ -457,13 +457,13 @@ export interface Service {
         body: DeviceDetails;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Register a device for receiving push notifications
@@ -488,13 +488,13 @@ export interface Service {
         body: DeviceDetails;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Unregister matching devices for push notifications
@@ -513,13 +513,13 @@ export interface Service {
      */
     unregisterAllPushDevices(X_Ably_Version?: Header<string, 'X-Ably-Version'>, format?: Query<"json" | "jsonp" | "msgpack" | "html">, deviceId?: Query<string>, clientId?: Query<string>): [(code: "2XX") => {}, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Get a device registration
@@ -545,13 +545,13 @@ export interface Service {
         body: DeviceDetails;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Update a device registration
@@ -577,13 +577,13 @@ export interface Service {
         body: DeviceDetails;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Unregister a single device for push notifications
@@ -601,13 +601,13 @@ export interface Service {
      */
     unregisterPushDevice(X_Ably_Version?: Header<string, 'X-Ably-Version'>, format?: Query<"json" | "jsonp" | "msgpack" | "html">, device_id: string): [(code: "2XX") => {}, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Update a device registration
@@ -633,13 +633,13 @@ export interface Service {
         body: DeviceDetails;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Reset a registered device's update token
@@ -665,13 +665,13 @@ export interface Service {
         body: DeviceDetails;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Publish a push notification to device(s)
@@ -721,13 +721,13 @@ export interface Service {
         recipient: Recipient;
     }, 'application/x-www-form-urlencoded'>): [(code: "2XX") => {}, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Retrieve usage statistics for an application
@@ -747,13 +747,13 @@ export interface Service {
         body: {};
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
     /**
      * Get the service time
@@ -778,12 +778,12 @@ export interface Service {
         body: string;
     }, (code: "Error", mediaType: "application/json") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "application/x-msgpack") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }, (code: "Error", mediaType: "text/html") => {
         body: Error;
-        headers: [Header<int64, "ErrorCode">, Header<string, "ErrorMessage">, Header<string, "ServerId">];
+        headers: [ErrorCode, ErrorMessage, ServerId];
     }];
 }

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/enums/CloudWatchEventSource.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/enums/CloudWatchEventSource.ts
@@ -4,16 +4,7 @@
  * @since 2018-11-25
  */
 export enum CloudWatchEventSource {
-    /**
-     *
-     */
     EC2 = 'EC2',
-    /**
-     *
-     */
     CODE_DEPLOY = 'CODE_DEPLOY',
-    /**
-     *
-     */
     HEALTH = 'HEALTH'
 }

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/enums/ConfigurationEventResourceType.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/enums/ConfigurationEventResourceType.ts
@@ -4,16 +4,7 @@
  * @since 2018-11-25
  */
 export enum ConfigurationEventResourceType {
-    /**
-     *
-     */
     CLOUDWATCH_ALARM = 'CLOUDWATCH_ALARM',
-    /**
-     *
-     */
     CLOUDFORMATION = 'CLOUDFORMATION',
-    /**
-     *
-     */
     SSM_ASSOCIATION = 'SSM_ASSOCIATION'
 }

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/enums/ConfigurationEventStatus.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/enums/ConfigurationEventStatus.ts
@@ -4,16 +4,7 @@
  * @since 2018-11-25
  */
 export enum ConfigurationEventStatus {
-    /**
-     *
-     */
     INFO = 'INFO',
-    /**
-     *
-     */
     WARN = 'WARN',
-    /**
-     *
-     */
     ERROR = 'ERROR'
 }

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/enums/FeedbackKey.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/enums/FeedbackKey.ts
@@ -4,8 +4,5 @@
  * @since 2018-11-25
  */
 export enum FeedbackKey {
-    /**
-     *
-     */
     INSIGHTS_FEEDBACK = 'INSIGHTS_FEEDBACK'
 }

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/enums/FeedbackValue.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/enums/FeedbackValue.ts
@@ -4,16 +4,7 @@
  * @since 2018-11-25
  */
 export enum FeedbackValue {
-    /**
-     *
-     */
     NOT_SPECIFIED = 'NOT_SPECIFIED',
-    /**
-     *
-     */
     USEFUL = 'USEFUL',
-    /**
-     *
-     */
     NOT_USEFUL = 'NOT_USEFUL'
 }

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/enums/LogFilter.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/enums/LogFilter.ts
@@ -4,16 +4,7 @@
  * @since 2018-11-25
  */
 export enum LogFilter {
-    /**
-     *
-     */
     ERROR = 'ERROR',
-    /**
-     *
-     */
     WARN = 'WARN',
-    /**
-     *
-     */
     INFO = 'INFO'
 }

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/enums/SeverityLevel.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/enums/SeverityLevel.ts
@@ -4,16 +4,7 @@
  * @since 2018-11-25
  */
 export enum SeverityLevel {
-    /**
-     *
-     */
     Low = 'Low',
-    /**
-     *
-     */
     Medium = 'Medium',
-    /**
-     *
-     */
     High = 'High'
 }

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/enums/Status.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/enums/Status.ts
@@ -4,16 +4,7 @@
  * @since 2018-11-25
  */
 export enum Status {
-    /**
-     *
-     */
     IGNORE = 'IGNORE',
-    /**
-     *
-     */
     RESOLVED = 'RESOLVED',
-    /**
-     *
-     */
     PENDING = 'PENDING'
 }

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/enums/Tier.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/enums/Tier.ts
@@ -4,24 +4,9 @@
  * @since 2018-11-25
  */
 export enum Tier {
-    /**
-     *
-     */
     DEFAULT = 'DEFAULT',
-    /**
-     *
-     */
     DOT_NET_CORE = 'DOT_NET_CORE',
-    /**
-     *
-     */
     DOT_NET_WORKER = 'DOT_NET_WORKER',
-    /**
-     *
-     */
     DOT_NET_WEB = 'DOT_NET_WEB',
-    /**
-     *
-     */
     SQL_SERVER = 'SQL_SERVER'
 }

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/HTTPStatusCode.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/HTTPStatusCode.ts
@@ -1,1 +1,6 @@
+
+/**
+ *
+ * @description HTTP Status Code.
+ */
 export type HTTPStatusCode = int64 & Minimum<100> & Maximum<599>;

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/MediaHeight.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/MediaHeight.ts
@@ -1,1 +1,6 @@
+
+/**
+ *
+ * @description The height of the media in pixels
+ */
 export type MediaHeight = int64 & Minimum<0>;

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/MediaKey.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/MediaKey.ts
@@ -1,1 +1,6 @@
+
+/**
+ *
+ * @description The Media Key identifier for this attachment.
+ */
 export type MediaKey = string & RegularExpression<'^([0-9]+)_([0-9]+)$'>;

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/MediaWidth.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/MediaWidth.ts
@@ -1,1 +1,6 @@
+
+/**
+ *
+ * @description The width of the media in pixels
+ */
 export type MediaWidth = int64 & Minimum<0>;

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/PollId.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/PollId.ts
@@ -1,1 +1,6 @@
+
+/**
+ *
+ * @description Unique identifier of this poll.
+ */
 export type PollId = string & RegularExpression<'^[0-9]{1,19}$'>;

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/Position.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/Position.ts
@@ -1,1 +1,6 @@
+
+/**
+ *
+ * @description A [GeoJson Position](https://tools.ietf.org/html/rfc7946#section-3.1.1) in the format `[longitude,latitude]`.
+ */
 export type Position = Array<double> & MaximumElements<2> & MinimumElements<2>;

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/Problem.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/Problem.ts
@@ -6,4 +6,8 @@ import { UnsupportedAuthenticationProblem } from '../models/UnsupportedAuthentic
 import { UsageCapExceededProblem } from '../models/UsageCapExceededProblem';
 import { ResourceNotFoundProblem } from '../models/ResourceNotFoundProblem';
 import { ResourceUnauthorizedProblem } from '../models/ResourceUnauthorizedProblem';
+/**
+ *
+ * @description An HTTP Problem Details object, as defined in IETF RFC 7807 (https://tools.ietf.org/html/rfc7807).
+ */
 export type Problem = Xor<GenericProblem, InvalidRequestProblem, ClientForbiddenProblem, ResourceNotFoundProblem, ResourceUnauthorizedProblem, DisallowedResourceProblem, UnsupportedAuthenticationProblem, UsageCapExceededProblem>;

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/TweetID.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/TweetID.ts
@@ -1,1 +1,6 @@
+
+/**
+ *
+ * @description Unique identifier of this Tweet. This is returned as a string in order to avoid complications with languages and tools that cannot handle large integers.
+ */
 export type TweetID = string & RegularExpression<'^[0-9]{1,19}$'>;

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/UserID.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/UserID.ts
@@ -1,1 +1,6 @@
+
+/**
+ *
+ * @description Unique identifier of this User. This is returned as a string in order to avoid complications with languages and tools that cannot handle large integers.
+ */
 export type UserID = string & RegularExpression<'^[0-9]{1,19}$'>;

--- a/adl/test/scenarios/v3/single/output/twitter/aliases/UserName.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/aliases/UserName.ts
@@ -1,1 +1,6 @@
+
+/**
+ *
+ * @description The Twitter handle (screen name) of this user.
+ */
 export type UserName = string & RegularExpression<'^[A-Za-z0-9_]{1,15}$'>;

--- a/adl/test/scenarios/v3/single/output/twitter/enums/PlaceType.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/enums/PlaceType.ts
@@ -4,28 +4,10 @@
  * @since 2.3
  */
 export enum PlaceType {
-    /**
-     *
-     */
     poi = 'poi',
-    /**
-     *
-     */
     neighborhood = 'neighborhood',
-    /**
-     *
-     */
     city = 'city',
-    /**
-     *
-     */
     admin = 'admin',
-    /**
-     *
-     */
     country = 'country',
-    /**
-     *
-     */
     unknown = 'unknown'
 }


### PR DESCRIPTION
OK, after several false starts, I think I finally have a pattern that will work, but I've only managed to type-alias-ify headers with it. I will follow up with parameters, requests and responses tomorrow. Hopefully,  I can get through that relatively quickly now.

### Notes
* I renamed TypeDeclaration to TypeSyntax because there's another TypeDeclaration as union of ts-morph XxxDeclaration
* I made TypeSyntax a class that can either be a string or a compiler node, and you can ask it for a string or node and it will convert lazily. 
* The string -> node conversion currently cheats and uses a TypeReference with a "name" that is arbitrary syntax for a type like "a | b | c". 
* This happens to work and happens to be what I accidentally did the last time. I experimented with parsing the text to a proper tree node for this conversion, but it had some side effects on the output: doc comments inside anonymous types were dropped, single quotes became double quotes.
* It might be interesting to revisit that, and also interesting to consider using compiler nodes instead of strings in more places over time.

### Other minor changes in this PR
* set docs on type aliases
* remove empty docs
* use summary for nodes that cannot have summary and description

### Commits
52b67fe has all the code changes
63be550 isolates the meaningful output change to headers
3c951e0 has the rest of the output changes (docs)

