### PR TITLE
Flesh out enum and model navigation

### DIFF
--- a/adl/core/linter/linter.ts
+++ b/adl/core/linter/linter.ts
@@ -72,7 +72,7 @@ export class Linter extends EventEmitter<Events> {
     // modelTypes and properties
     for (const modelType of files.modelTypes) {
       yield* [ ... this.iterEmit('ModelType', model, modelType)].select( each => each.result);
-      for (const property of modelType.getProperties()) {
+      for (const property of modelType.properties) {
         yield* [ ... this.iterEmit('Property', model, property)].select( each => each.result);
       }
     }

--- a/adl/core/model/schema/enum.ts
+++ b/adl/core/model/schema/enum.ts
@@ -3,14 +3,14 @@ import { EnumDeclaration, EnumMember } from 'ts-morph';
 import { literal, normalizeIdentifier, TypeSyntax } from '../../support/codegen';
 import { createDocs } from '../../support/doc-tag';
 import { ApiModel } from '../api-model';
-import { Collection, Identity } from '../types';
+import { Identity } from '../types';
 import { NamedElement } from '../typescript/named-element';
 import { SchemaInitializer } from '../typescript/schema';
 import { TypeReference } from './type';
 
 export interface EnumInitializer extends SchemaInitializer {
   extensible?: boolean;
-  readonly values: Collection<EnumValue>;
+  readonly values: Array<EnumValue>;
 }
 
 export interface EnumValue {

--- a/adl/core/model/schema/enum.ts
+++ b/adl/core/model/schema/enum.ts
@@ -1,7 +1,7 @@
 import { isAnonymous } from '@azure-tools/sourcemap';
 import { EnumDeclaration, EnumMember, ts } from 'ts-morph';
 import { normalizeIdentifier, TypeSyntax } from '../../support/codegen';
-import { createDocs } from '../../support/doc-tag';
+import { createDocs, hasTag, setTag } from '../../support/doc-tag';
 import { ApiModel } from '../api-model';
 import { Identity } from '../types';
 import { NamedElement } from '../typescript/named-element';
@@ -70,6 +70,17 @@ export class EnumValueElement extends NamedElement<EnumMember> {
   constructor(node: EnumMember) {
     super(node);
   }
+
+  get value(): string | number | undefined {
+    return this.node.getValue();
+  }
+  set value(v: string | number | undefined) {
+    if (v == undefined) {
+      this.node.removeInitializer();
+      return;
+    }
+    this.node.setValue(v);
+  }
 }
 
 export class EnumType extends NamedElement<EnumDeclaration> implements TypeReference {
@@ -86,6 +97,13 @@ export class EnumType extends NamedElement<EnumDeclaration> implements TypeRefer
 
   get values(): Array<EnumValueElement> {
     return this.node.getMembers().map(each => new EnumValueElement(each));
+  }
+
+  get extensible(): boolean {
+    return hasTag(this.node, 'extensible');
+  }
+  set extensible(value: boolean) {
+    setTag(this.node, 'extensible', value);
   }
 
   createValue() {

--- a/adl/core/model/schema/enum.ts
+++ b/adl/core/model/schema/enum.ts
@@ -9,8 +9,7 @@ import { SchemaInitializer } from '../typescript/schema';
 import { TypeReference } from './type';
 
 export interface EnumInitializer extends SchemaInitializer {
-  extensible?: boolean;
-  readonly values: Array<EnumValue>;
+  extensible: boolean;
 }
 
 export interface EnumValue {

--- a/adl/core/model/schema/enum.ts
+++ b/adl/core/model/schema/enum.ts
@@ -1,6 +1,6 @@
 import { isAnonymous } from '@azure-tools/sourcemap';
-import { EnumDeclaration, EnumMember } from 'ts-morph';
-import { literal, normalizeIdentifier, TypeSyntax } from '../../support/codegen';
+import { EnumDeclaration, EnumMember, ts } from 'ts-morph';
+import { normalizeIdentifier, TypeSyntax } from '../../support/codegen';
 import { createDocs } from '../../support/doc-tag';
 import { ApiModel } from '../api-model';
 import { Identity } from '../types';
@@ -59,7 +59,9 @@ export function createEnum(api: ApiModel, identity: Identity, values: Array<Enum
 
   // anonymous enums are far simpler, since they are purely inline information
   return {
-    declaration: new TypeSyntax(values.map(v => literal(v.value)).join(' | ')),
+    declaration: new TypeSyntax(
+      ts.createUnionTypeNode(
+        values.map(v => ts.createLiteralTypeNode(ts.createLiteral(v.value))))),
     requiredReferences: [],
   };
 }

--- a/adl/core/model/schema/model.ts
+++ b/adl/core/model/schema/model.ts
@@ -52,7 +52,7 @@ export class ModelType extends NamedElement<InterfaceDeclaration> implements Typ
     return new TypeSyntax(this.node.getName());
   }
 
-  getProperties(): Iterable<Property> {
+  getProperties(): Array<Property> {
     return this.node.getProperties().map(each => new Property(each));
   }
 

--- a/adl/core/model/schema/model.ts
+++ b/adl/core/model/schema/model.ts
@@ -52,7 +52,7 @@ export class ModelType extends NamedElement<InterfaceDeclaration> implements Typ
     return new TypeSyntax(this.node.getName());
   }
 
-  getProperties(): Array<Property> {
+  get properties(): Array<Property> {
     return this.node.getProperties().map(each => new Property(each));
   }
 

--- a/adl/core/model/schema/property.ts
+++ b/adl/core/model/schema/property.ts
@@ -1,5 +1,5 @@
-import { PropertySignature, PropertySignatureStructure, StructureKind } from 'ts-morph';
-import { normalizeIdentifier } from '../../support/codegen';
+import { PropertySignature, PropertySignatureStructure, StructureKind, ts } from 'ts-morph';
+import { normalizeIdentifier, TypeSyntax } from '../../support/codegen';
 import { createDocs } from '../../support/doc-tag';
 import { addNullable } from '../../support/typescript';
 import { NamedElement } from '../typescript/named-element';
@@ -33,11 +33,14 @@ export class Property extends NamedElement<PropertySignature> {
   }
 
   get type(): TypeReference {
-    return <TypeReference><any>{};
+    return {
+      declaration: new TypeSyntax(this.node.getTypeNode()?.compilerNode ?? ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)),
+      requiredReferences: [] // todo
+    };
   }
 
   set type(typeReference: TypeReference) {
-    // shh
+    this.node.setType(typeReference.declaration.text);
   }
 }
 

--- a/adl/core/model/schema/type.ts
+++ b/adl/core/model/schema/type.ts
@@ -33,28 +33,28 @@ export interface TypeReference {
   readonly sourceFile?: SourceFile;
 
   readonly isInline?: boolean;
-  typeParameters?: Array<TypeParameterDeclarationStructure>;
+  readonly typeParameters?: Array<TypeParameterDeclarationStructure>;
 }
 
 export interface SchemaTypeReference extends TypeReference {
 }
 
 export interface ParameterTypeReference extends TypeReference {
-  name: string;
-  description?: string;
-  required: boolean;
-  location: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly required: boolean;
+  readonly location: string;
 }
 
 export interface HeaderTypeReference extends TypeReference {
 }
 
 export interface RequestBodyTypeReference extends TypeReference {
-  required: boolean;
-  description?: string;
+  readonly required: boolean;
+  readonly description?: string;
 }
 
 export interface ResponseTypeReference extends TypeReference {
-  description?: string;
-  code?: string;
+  readonly description?: string;
+  readonly code?: string;
 }

--- a/adl/core/model/types.ts
+++ b/adl/core/model/types.ts
@@ -5,15 +5,6 @@ export type Identity = string | anonymous;
 
 export type URL = string;
 
-export interface ReadOnlyCollection<T> {
-  get(): Array<T>;
-}
-
-export interface Collection<T> extends ReadOnlyCollection<T> {
-  push(...values: Array<T>): void;
-  remove(value: T): void;
-}
-
 export interface Folders {
   anonymous: Directory;
   alias: Directory;

--- a/adl/core/model/typescript/named-element.ts
+++ b/adl/core/model/typescript/named-element.ts
@@ -32,15 +32,15 @@ export class NamedElement<TNode extends Node & NamedNodeSpecificBase<Identifier 
   }
 
   get summary() {
-    return getFirstDoc(this.node).getDescription();
+    return getFirstDoc(this.node).getDescription().trim();
   }
 
-  set summary(value: string | undefined) {
+  set summary(value: string) {
     getFirstDoc(this.node).setDescription(value || '\n');
   }
 
   get description() {
-    return getTagValue(this.node, 'description');
+    return getTagValue(this.node, 'description')?.trim();
   }
   set description(value: string | undefined) {
     setTag(this.node, 'description', value);

--- a/adl/core/serialization/openapi/common.ts
+++ b/adl/core/serialization/openapi/common.ts
@@ -1,8 +1,7 @@
 import { length } from '@azure-tools/linq';
 import { common, StringFormat, v2, v3, vendorExtensions } from '@azure-tools/openapi';
-import { Element } from '../../model/element';
-import { Collection } from '../../model/types';
 import { fail } from 'assert';
+import { Element } from '../../model/element';
 
 export async function toArray<T>(g: AsyncGenerator<T>) {
   const result = new Array<T>();
@@ -12,7 +11,7 @@ export async function toArray<T>(g: AsyncGenerator<T>) {
   return result;
 }
 
-export async function push<T>(destination: Array<T> | Collection<T>, g: AsyncGenerator<T>) {
+export async function push<T>(destination: Array<T>, g: AsyncGenerator<T>) {
   for await (const each of g) {
     destination.push(each);
   }

--- a/adl/core/serialization/openapi/common/schema.ts
+++ b/adl/core/serialization/openapi/common/schema.ts
@@ -198,8 +198,6 @@ export async function processEnumSchema<T extends OAIModel>(schema: v3.Schema | 
     summary: value.description,
   }));
 
-  // enums are a bit funny -- they can define their name inside the x-ms-enum declaration 
-  // which means there can be multiple declarations for the same enum 
   const result = createEnum($.api, name, values, {
     extensible,
     ...commonProperties(schema),

--- a/adl/core/support/codegen.ts
+++ b/adl/core/support/codegen.ts
@@ -10,24 +10,6 @@ export function normalizeIdentifier(value: string) {
   return /[^\w]/g.exec(value) ? `'${value.replace(/'/g, '\\\'')}'` : value;
 }
 
-export function literal(value: string | number | boolean | null | undefined) {
-  if (value === null) {
-    return 'null';
-  }
-  if (value === undefined) {
-    return 'undefined';
-  }
-  if (typeof value == 'string') {
-    return stringLiteral(value);
-  }
-  return value.toString();
-}
-
-export function stringLiteral(value: string) {
-  return JSON.stringify(value || '');
-
-}
-
 export function normalizeName(value: string ) {
   if (/^[^a-zA-Z]/.test(value)) {
     // \w matches digits, but we can't lead with a digit

--- a/adl/core/support/codegen.ts
+++ b/adl/core/support/codegen.ts
@@ -54,7 +54,7 @@ export class TypeSyntax {
   }
 
   get node() {
-    if (!this.#node) {
+    if (this.#node === undefined) {
       // NOTE: We currently get away with putting arbitrary syntax in a type
       // reference node's "name" here. It would be more correct to to parse the
       // text here into a proper tree, but that costs extra parsing and has the
@@ -65,7 +65,7 @@ export class TypeSyntax {
   }
 
   get text() {
-    if (!this.#text) {
+    if (this.#text === undefined) {
       this.#text = printNode(this.#node!);
     }
     return this.#text;

--- a/adl/core/test/navigation.ts
+++ b/adl/core/test/navigation.ts
@@ -1,5 +1,5 @@
 import { suite, test } from '@testdeck/mocha';
-import { deepEqual } from 'assert';
+import { deepEqual, equal } from 'assert';
 import { resolve } from 'path';
 import { ApiModel } from '../model/api-model';
 import { ResponseCollection } from '../model/http/operation';
@@ -14,6 +14,7 @@ const scenarios = `${__dirname}/../../../test/scenarios/adl`;
     const api = await ApiModel.loadADL(inputRoot);
 
     this.navigateModels(api);
+    this.navigateEnums(api);
     this.navigateOperations(api);
   }
 
@@ -59,5 +60,35 @@ const scenarios = `${__dirname}/../../../test/scenarios/adl`;
     deepEqual(modelTypeNames, ['Person', 'responseValue2']);
 
     const personModel = api.modelTypes[0];
+  }
+
+  private navigateEnums(api: ApiModel) {
+    const enumNames = api.enumTypes.map(each => each.name);
+    deepEqual(enumNames, ['Color', 'Priority']);
+
+    const colorEnum = api.enumTypes[0];
+    equal(colorEnum.name, 'Color');
+    equal(colorEnum.summary, 'Represents a color');
+    equal(colorEnum.extensible, true);
+
+    const colorValueNames = colorEnum.values.map(each => each.name);
+    deepEqual(colorValueNames, ['Red', 'Blue', 'None']);
+
+    const colorValueSummaries = colorEnum.values.map(each => each.summary);
+    deepEqual(colorValueSummaries, ['The color red', 'The color blue', 'No color']);
+
+    const colorValues = colorEnum.values.map(each => each.value);
+    deepEqual(colorValues, ['Red', 'Blue', '']);
+
+    const priorityEnum = api.enumTypes[1];
+    equal(priorityEnum.name, 'Priority');
+    equal(priorityEnum.summary, '');
+    equal(priorityEnum.extensible, false);
+
+    const priorityValueSummaries = priorityEnum.values.map(each => each.summary);
+    deepEqual(priorityValueSummaries, ['', '', '']);
+
+    const priorityValues = priorityEnum.values.map(each => each.value);
+    deepEqual(priorityValues, [0, 1, 2]);
   }
 }

--- a/adl/core/test/navigation.ts
+++ b/adl/core/test/navigation.ts
@@ -9,48 +9,55 @@ const scenarios = `${__dirname}/../../../test/scenarios/adl`;
 
 @suite class TestNavigation {
 
-  @test async first() { 
+  @test async 'Load and navigate ADL'() { 
     const inputRoot = resolve(scenarios, 'sampleProject');
     const api = await ApiModel.loadADL(inputRoot);
 
-    const models = api.modelTypes.map( each => each.name );
-    deepEqual(models, ['Person', 'responseValue2']);
+    this.navigateModels(api);
+    this.navigateOperations(api);
+  }
 
+  private navigateOperations(api: ApiModel) {
     const groups = api.operationGroups;
-    
+
     deepEqual(groups.map(each => each.name), ['myOperations']);
 
     const operations = groups[0].operations;
-    
+
     deepEqual(operations.map(each => each.name), ['first']);
 
-    const responseCollections =  api.responseCollections;
+    this.navigateResponses(api);
+  }
+
+  private navigateResponses(api: ApiModel) {
+    const responseCollections = api.responseCollections;
     deepEqual(responseCollections.length, 1, 'should have one response collection');
-    
+
     const col = responseCollections[0];
 
     // strongly type the expected collections type
-    const collection = <ResponseCollection> col.target;
+    const collection = <ResponseCollection>col.target;
     const responses = collection.responses;
 
     deepEqual(responses.length, 6, 'should have 6 responses in the collection');
 
-    for( const response of responses ) {
-      const r = isDeclaration( response ) ? response.target : response;
+    for (const response of responses) {
+      const r = isDeclaration(response) ? response.target : response;
       const c = r.criteria;
-      let discard =  c.codes; // will throw if it's not good
+      let discard = c.codes; // will throw if it's not good
       discard = c.mediaTypes; // will throw if it's not good
-      //console.log(  c.codes.join(',') );
-      // console.log( c.mediaTypes.join(',') );
       const s = r.result;
-      if( s ) {
+      if (s) {
         const result = isDeclaration(s) ? s.target : s;
-        //console.log( result.body?.declaration.text || 'No Body Present' ) ;
-        const discard = result.body?.declaration.text; // will throw if it's not good
+        const discard = result.body?.declaration.text;
       }
-    } 
-
-
+    }
   }
- 
+
+  private navigateModels(api: ApiModel) {
+    const modelTypeNames = api.modelTypes.map(each => each.name);
+    deepEqual(modelTypeNames, ['Person', 'responseValue2']);
+
+    const personModel = api.modelTypes[0];
+  }
 }

--- a/adl/core/test/navigation.ts
+++ b/adl/core/test/navigation.ts
@@ -60,6 +60,14 @@ const scenarios = `${__dirname}/../../../test/scenarios/adl`;
     deepEqual(modelTypeNames, ['Person', 'responseValue2']);
 
     const personModel = api.modelTypes[0];
+    equal(personModel.name, 'Person');
+
+    const properties = personModel.properties;
+    const propertyNames = properties.map(each => each.name);
+    deepEqual(propertyNames, [ 'name', 'age' ]);
+
+    const propertyTypes = properties.map(each => each.type.declaration.text);
+    deepEqual(propertyTypes, ['string', 'number']);
   }
 
   private navigateEnums(api: ApiModel) {

--- a/adl/test/scenarios/adl/sampleProject/enums/color.ts
+++ b/adl/test/scenarios/adl/sampleProject/enums/color.ts
@@ -1,0 +1,13 @@
+/**
+ * Represents a color
+ * 
+ * @extensible
+ */
+export enum Color {
+  /** The color red */
+  Red = 'Red',
+  /** The color blue */
+  Blue = 'Blue',
+  /** No color */
+  None = '',
+}

--- a/adl/test/scenarios/adl/sampleProject/enums/priority.ts
+++ b/adl/test/scenarios/adl/sampleProject/enums/priority.ts
@@ -1,0 +1,5 @@
+export enum Priority {
+  Zero = 0,
+  One = 1,
+  Two = 2,
+}


### PR DESCRIPTION
The first bunch of commits are cleanup, the last two implement the change in the PR title:

* Retrieve enum values
* Retrieve model property types
* Add some test coverage of above