### PR TITLE
enable static loader for vscode extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,9 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/adl/extension"
       ],
+      "env": {
+        "no-static-loader": "true"
+      },
       "outFiles": [
         "${workspaceRoot}/adl/extension/dist/client/**/*.js"
       ]

--- a/adl/cli/main.ts
+++ b/adl/cli/main.ts
@@ -71,9 +71,9 @@ async function main() {
     case 'import':
       return cmdImport(commandLine);
 
-    // temporarily disable
-    // case 'merge':
-    //  return cmdMerge(commandLine);
+      // temporarily disable
+      // case 'merge':
+      //  return cmdMerge(commandLine);
 
     default:
       return console.log('No command given. Use --help for more information.');

--- a/adl/extension/client/client.ts
+++ b/adl/extension/client/client.ts
@@ -3,14 +3,21 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+// using static-link'd dependencies: 
+let usingStaticLoader = false;
+if (process.env['no-static-loader'] === undefined && require('fs').existsSync(`${__dirname}/../../dist/static-loader.js`)) {
+  usingStaticLoader = true;
+  require(`${__dirname}/../../dist/static-loader.js`).load(`${__dirname}/../../dist/static_modules.fs`);
+}
+
 import * as path from 'path';
 import { ExtensionContext, workspace } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
 
-
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
+
   // The server is implemented in node
   const serverModule = context.asAbsolutePath(
     path.join('dist', 'server', 'server.js')
@@ -52,6 +59,8 @@ export function activate(context: ExtensionContext) {
 
   // Start the client. This will also launch the server
   client.start();
+
+  client.outputChannel.appendLine(`ADL Language Client started. [static-loader: ${usingStaticLoader}]`);
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/adl/extension/package.json
+++ b/adl/extension/package.json
@@ -1,10 +1,11 @@
 {
   "name": "adl-language",
   "version": "1.0.0",
+  "publisher": "ms-vscode",
   "description": "ADL Language Service",
   "main": "dist/client/client",
   "engines": {
-    "vscode": "^1.43.0"
+    "vscode": "^1.45.0"
   },
   "activationEvents": [
     "onLanguage:typescript"
@@ -35,7 +36,8 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run build",
+    "vscode:prepublish": "npm run static-link && npm run build",
+    "static-link": "static-link --no-node-modules --debug",
     "eslint-fix": "eslint  . --fix --ext .ts",
     "eslint": "eslint  . --ext .ts",
     "build": "tsc -p .",
@@ -48,8 +50,7 @@
     "url": "git+https://github.com/Azure/adl.git"
   },
   "keywords": [
-    "adl",
-    "cli"
+    "adl"
   ],
   "author": "",
   "license": "MIT",
@@ -59,19 +60,29 @@
   "homepage": "https://github.com/Azure/adl#readme",
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
-    "mocha": "7.1.2",
     "@types/mocha": "~7.0.2",
-    "typescript": "~3.9.5",
+    "@types/node": "~12.7.2",
+    "@types/vscode": "~1.45.0",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",
-    "source-map-support": "0.5.19",
     "eslint": "6.8.0",
-    "@types/vscode": "~1.45.0",
-    "vscode-test": "~1.3.0"
-  },
-  "dependencies": {
+    "mocha": "7.1.2",
+    "source-map-support": "0.5.19",
+    "static-link": "^0.2.4",
+    "typescript": "~3.9.5",
+    "vscode-test": "~1.3.0",
     "vscode-languageclient": "~6.1.3",
     "vscode-languageserver": "^6.1.1",
-    "vscode-languageserver-textdocument": "^1.0.1"
+    "vscode-languageserver-textdocument": "^1.0.1",
+    "@azure-tools/adl.core": "~1.0.0"
+  },
+  "static-link": {
+    "entrypoints": [],
+    "dependencies": {
+      "vscode-languageclient": "~6.1.3",
+      "vscode-languageserver": "^6.1.1",
+      "vscode-languageserver-textdocument": "^1.0.1",
+      "@azure-tools/adl.core": "~1.0.0"
+    }
   }
 }

--- a/adl/extension/server/server.ts
+++ b/adl/extension/server/server.ts
@@ -2,13 +2,22 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
+
+// using static-link'd dependencies: 
+let usingStaticLoader = false;
+
+if (process.env['no-static-loader'] === undefined && require('fs').existsSync(`${__dirname}/../../dist/static-loader.js`)) {
+  usingStaticLoader = true;
+  require(`${__dirname}/../../dist/static-loader.js`).load(`${__dirname}/../../dist/static_modules.fs`);
+}
 import { CompletionItem, CompletionItemKind, createConnection, Diagnostic, DiagnosticSeverity, DidChangeConfigurationNotification, InitializeParams, InitializeResult, ProposedFeatures, TextDocumentPositionParams, TextDocuments, TextDocumentSyncKind } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-
 
 // Create a connection for the server. The connection uses Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
 const connection = createConnection(ProposedFeatures.all);
+
+connection.console.info(`ADL Language Server started. [static-loader: ${usingStaticLoader}]`)
 
 // Create a simple text document manager. The text document manager
 // supports full document sync only

--- a/adl/extension/server/server.ts
+++ b/adl/extension/server/server.ts
@@ -17,7 +17,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 // Also include all preview / proposed LSP features.
 const connection = createConnection(ProposedFeatures.all);
 
-connection.console.info(`ADL Language Server started. [static-loader: ${usingStaticLoader}]`)
+connection.console.info(`ADL Language Server started. [static-loader: ${usingStaticLoader}]`);
 
 // Create a simple text document manager. The text document manager
 // supports full document sync only


### PR DESCRIPTION
Due to the large number of files that we drag in inside our extension, I've enabled the use of the static linker when building the vscode package.

All dependencies that the vscode extension needs should be put in both `devDependencies`  and the `static-link.dependencies` collections in package.json.