### PR TITLE
Use datetime casing matching primitives.ts

### DIFF
--- a/adl/core/model/schema/primitive.ts
+++ b/adl/core/model/schema/primitive.ts
@@ -51,7 +51,7 @@ export const Primitives = {
   date: createPrimitiveType('date'),
   time: createPrimitiveType('time'),
   unixtime: createPrimitiveType('unixtime'),
-  dateTime: createPrimitiveType('dateTime'),
+  datetime: createPrimitiveType('datetime'),
   duration: createPrimitiveType('duration'),
   uuid: createPrimitiveType('uuid'),
   uri: createPrimitiveType('uri'),

--- a/adl/core/serialization/openapi/common/schema.ts
+++ b/adl/core/serialization/openapi/common/schema.ts
@@ -71,7 +71,7 @@ export async function processTimeSchema<T extends OAIModel>(schema: v3.Schema|v2
 export async function processDateTimeSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>, encoding?: EncodingReference): Promise<SchemaTypeReference> {
   $.assertNoForbiddenProperties(schema, ...<any>notPrimitiveProperties);
 
-  return wrapWithAliasIfNeeded(schema, $.api.primitives.dateTime, $, encoding);
+  return wrapWithAliasIfNeeded(schema, $.api.primitives.datetime, $, encoding);
 }
 
 export async function processDurationSchema<T extends OAIModel>(schema: v3.Schema|v2.Schema, $: Context<T>): Promise<SchemaTypeReference> {

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiReleaseContractProperties.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiReleaseContractProperties.ts
@@ -13,12 +13,12 @@ export interface ApiReleaseContractProperties {
      * @description The time the API was released. The date conforms to the following format: yyyy-MM-ddTHH:mm:ssZ as specified by the ISO 8601 standard.
      * @since 2019-12-01
      */
-    readonly createdDateTime?: dateTime;
+    readonly createdDateTime?: datetime;
     /**
      * @description The time the API release was updated.
      * @since 2019-12-01
      */
-    readonly updatedDateTime?: dateTime;
+    readonly updatedDateTime?: datetime;
     /**
      * @description Release Notes
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiRevisionContract.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/ApiRevisionContract.ts
@@ -18,12 +18,12 @@ export interface ApiRevisionContract {
      * @description The time the API Revision was created. The date conforms to the following format: yyyy-MM-ddTHH:mm:ssZ as specified by the ISO 8601 standard.
      * @since 2019-12-01
      */
-    readonly createdDateTime?: dateTime;
+    readonly createdDateTime?: datetime;
     /**
      * @description The time the API Revision were updated. The date conforms to the following format: yyyy-MM-ddTHH:mm:ssZ as specified by the ISO 8601 standard.
      * @since 2019-12-01
      */
-    readonly updatedDateTime?: dateTime;
+    readonly updatedDateTime?: datetime;
     /**
      * @description Description of the API Revision.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/CertificateContractProperties.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/CertificateContractProperties.ts
@@ -19,5 +19,5 @@ export interface CertificateContractProperties {
      *
      * @since 2019-12-01
      */
-    expirationDate: dateTime;
+    expirationDate: datetime;
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/GatewayTokenRequestContract.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/GatewayTokenRequestContract.ts
@@ -14,5 +14,5 @@ export interface GatewayTokenRequestContract {
      *
      * @since 2019-12-01
      */
-    expiry: dateTime;
+    expiry: datetime;
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueCommentContractProperties.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueCommentContractProperties.ts
@@ -13,7 +13,7 @@ export interface IssueCommentContractProperties {
      * @description Date and time when the comment was created.
      * @since 2019-12-01
      */
-    createdDate?: dateTime;
+    createdDate?: datetime;
     /**
      * @description A resource identifier for the user who left the comment.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueContractBaseProperties.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/IssueContractBaseProperties.ts
@@ -8,7 +8,7 @@ export interface IssueContractBaseProperties {
      * @description Date and time when the issue was created.
      * @since 2019-12-01
      */
-    createdDate?: dateTime;
+    createdDate?: datetime;
     /**
      * @description Status of the issue.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/OperationResultContract.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/OperationResultContract.ts
@@ -21,13 +21,13 @@ export interface OperationResultContract {
      *
      * @since 2019-12-01
      */
-    started?: dateTime;
+    started?: datetime;
     /**
      * @description Last update time of an async operation. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard.
      *
      * @since 2019-12-01
      */
-    updated?: dateTime;
+    updated?: datetime;
     /**
      * @description Optional result info.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/QuotaCounterContract.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/QuotaCounterContract.ts
@@ -19,13 +19,13 @@ export interface QuotaCounterContract {
      *
      * @since 2019-12-01
      */
-    periodStartTime: dateTime;
+    periodStartTime: datetime;
     /**
      * @description The date of the end of Counter Period. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard.
      *
      * @since 2019-12-01
      */
-    periodEndTime: dateTime;
+    periodEndTime: datetime;
     /**
      * @description Quota Value Properties
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/ReportRecordContract.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/ReportRecordContract.ts
@@ -14,7 +14,7 @@ export interface ReportRecordContract {
      *
      * @since 2019-12-01
      */
-    timestamp?: dateTime;
+    timestamp?: datetime;
     /**
      * @description Length of aggregation period.  Interval must be multiple of 15 minutes and may not be zero. The value should be in ISO 8601 format (http://en.wikipedia.org/wiki/ISO_8601#Durations).
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/RequestReportRecordContract.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/RequestReportRecordContract.ts
@@ -58,7 +58,7 @@ export interface RequestReportRecordContract {
      * @description The date and time when this request was received by the gateway in ISO 8601 format.
      * @since 2019-12-01
      */
-    timestamp?: dateTime;
+    timestamp?: datetime;
     /**
      * @description Specifies if response cache was involved in generating the response. If the value is none, the cache was not used. If the value is hit, cached response was returned. If the value is miss, the cache was used but lookup resulted in a miss and request was fulfilled by the backend.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/SubscriptionContractProperties.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/SubscriptionContractProperties.ts
@@ -29,31 +29,31 @@ export interface SubscriptionContractProperties {
      *
      * @since 2019-12-01
      */
-    readonly createdDate?: dateTime;
+    readonly createdDate?: datetime;
     /**
      * @description Subscription activation date. The setting is for audit purposes only and the subscription is not automatically activated. The subscription lifecycle can be managed by using the `state` property. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard.
      *
      * @since 2019-12-01
      */
-    startDate?: dateTime;
+    startDate?: datetime;
     /**
      * @description Subscription expiration date. The setting is for audit purposes only and the subscription is not automatically expired. The subscription lifecycle can be managed by using the `state` property. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard.
      *
      * @since 2019-12-01
      */
-    expirationDate?: dateTime;
+    expirationDate?: datetime;
     /**
      * @description Date when subscription was cancelled or expired. The setting is for audit purposes only and the subscription is not automatically cancelled. The subscription lifecycle can be managed by using the `state` property. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard.
      *
      * @since 2019-12-01
      */
-    endDate?: dateTime;
+    endDate?: datetime;
     /**
      * @description Upcoming subscription expiration notification date. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard.
      *
      * @since 2019-12-01
      */
-    notificationDate?: dateTime;
+    notificationDate?: datetime;
     /**
      * @description Subscription primary key. This property will not be filled on 'GET' operations! Use '/listSecrets' POST request to get the value.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/SubscriptionUpdateParameterProperties.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/SubscriptionUpdateParameterProperties.ts
@@ -18,7 +18,7 @@ export interface SubscriptionUpdateParameterProperties {
      * @description Subscription expiration date. The setting is for audit purposes only and the subscription is not automatically expired. The subscription lifecycle can be managed by using the `state` property. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard.
      * @since 2019-12-01
      */
-    expirationDate?: dateTime;
+    expirationDate?: datetime;
     /**
      * @description Subscription name.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/TenantConfigurationSyncStateContract.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/TenantConfigurationSyncStateContract.ts
@@ -34,11 +34,11 @@ export interface TenantConfigurationSyncStateContract {
      *
      * @since 2019-12-01
      */
-    syncDate?: dateTime;
+    syncDate?: datetime;
     /**
      * @description The date of the latest configuration change. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard.
      *
      * @since 2019-12-01
      */
-    configurationChangeDate?: dateTime;
+    configurationChangeDate?: datetime;
 }

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/UserContractProperties.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/UserContractProperties.ts
@@ -25,7 +25,7 @@ export interface UserContractProperties extends UserEntityBaseParameters {
      *
      * @since 2019-12-01
      */
-    registrationDate?: dateTime;
+    registrationDate?: datetime;
     /**
      * @description Collection of groups user is part of.
      * @since 2019-12-01

--- a/adl/test/scenarios/v2/multiple/apimanagement/output/models/UserTokenParameterProperties.ts
+++ b/adl/test/scenarios/v2/multiple/apimanagement/output/models/UserTokenParameterProperties.ts
@@ -14,5 +14,5 @@ export interface UserTokenParameterProperties {
      *
      * @since 2019-12-01
      */
-    expiry: dateTime;
+    expiry: datetime;
 }

--- a/adl/test/scenarios/v2/multiple/management-keyvault/output/models/DeletedVaultProperties.ts
+++ b/adl/test/scenarios/v2/multiple/management-keyvault/output/models/DeletedVaultProperties.ts
@@ -18,12 +18,12 @@ export interface DeletedVaultProperties {
      * @description The deleted date.
      * @since 2019-09-01
      */
-    readonly deletionDate?: dateTime;
+    readonly deletionDate?: datetime;
     /**
      * @description The scheduled purged date.
      * @since 2019-09-01
      */
-    readonly scheduledPurgeDate?: dateTime;
+    readonly scheduledPurgeDate?: datetime;
     /**
      * @description Tags of the original vault.
      * @since 2019-09-01

--- a/adl/test/scenarios/v2/single/output/redis/models/UpgradeNotification.ts
+++ b/adl/test/scenarios/v2/single/output/redis/models/UpgradeNotification.ts
@@ -13,7 +13,7 @@ export interface UpgradeNotification {
      * @description Timestamp when upgrade notification occurred.
      * @since 2018-03-01
      */
-    readonly timestamp?: dateTime;
+    readonly timestamp?: datetime;
     /**
      * @description Details about this upgrade notification
      * @since 2018-03-01

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/models/ConfigurationEvent.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/models/ConfigurationEvent.ts
@@ -24,7 +24,7 @@ export interface ConfigurationEvent {
      * @description  The timestamp of the event.
      * @since 2018-11-25
      */
-    EventTime?: dateTime;
+    EventTime?: datetime;
     /**
      * @description  The details of the event in plain text.
      * @since 2018-11-25

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/models/ListConfigurationHistoryRequest.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/models/ListConfigurationHistoryRequest.ts
@@ -15,12 +15,12 @@ export interface ListConfigurationHistoryRequest {
      * @description The start time of the event.
      * @since 2018-11-25
      */
-    StartTime?: dateTime;
+    StartTime?: datetime;
     /**
      * @description The end time of the event.
      * @since 2018-11-25
      */
-    EndTime?: dateTime;
+    EndTime?: datetime;
     /**
      * @description The status of the configuration update event. Possible values include INFO, WARN, and ERROR.
      * @since 2018-11-25

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/models/ListProblemsRequest.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/models/ListProblemsRequest.ts
@@ -14,12 +14,12 @@ export interface ListProblemsRequest {
      * @description The time when the problem was detected, in epoch seconds. If you don't specify a time frame for the request, problems within the past seven days are returned.
      * @since 2018-11-25
      */
-    StartTime?: dateTime;
+    StartTime?: datetime;
     /**
      * @description The time when the problem ended, in epoch seconds. If not specified, problems within the past seven days are returned.
      * @since 2018-11-25
      */
-    EndTime?: dateTime;
+    EndTime?: datetime;
     /**
      * @description The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.
      * @since 2018-11-25

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/models/Observation.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/models/Observation.ts
@@ -21,12 +21,12 @@ export interface Observation {
      * @description The time when the observation was first detected, in epoch seconds.
      * @since 2018-11-25
      */
-    StartTime?: dateTime;
+    StartTime?: datetime;
     /**
      * @description The time when the observation ended, in epoch seconds.
      * @since 2018-11-25
      */
-    EndTime?: dateTime;
+    EndTime?: datetime;
     /**
      * @description The source type of the observation.
      * @since 2018-11-25
@@ -46,7 +46,7 @@ export interface Observation {
      * @description The timestamp in the CloudWatch Logs that specifies when the matched line occurred.
      * @since 2018-11-25
      */
-    LineTime?: dateTime;
+    LineTime?: datetime;
     /**
      * @description The log text of the observation.
      * @since 2018-11-25

--- a/adl/test/scenarios/v3/single/output/aws-app-insights/models/Problem.ts
+++ b/adl/test/scenarios/v3/single/output/aws-app-insights/models/Problem.ts
@@ -37,12 +37,12 @@ export interface Problem {
      * @description The time when the problem started, in epoch seconds.
      * @since 2018-11-25
      */
-    StartTime?: dateTime;
+    StartTime?: datetime;
     /**
      * @description The time when the problem ended, in epoch seconds.
      * @since 2018-11-25
      */
-    EndTime?: dateTime;
+    EndTime?: datetime;
     /**
      * @description A measure of the level of impact of the problem.
      * @since 2018-11-25

--- a/adl/test/scenarios/v3/single/output/twitter/models/Poll.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/models/Poll.ts
@@ -14,7 +14,7 @@ export interface Poll {
      *
      * @since 2.3
      */
-    end_datetime?: dateTime;
+    end_datetime?: datetime;
     /**
      *
      * @since 2.3

--- a/adl/test/scenarios/v3/single/output/twitter/models/Tweet.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/models/Tweet.ts
@@ -33,7 +33,7 @@ export interface Tweet {
      * @description Creation time of the Tweet.
      * @since 2.3
      */
-    created_at?: dateTime;
+    created_at?: datetime;
     /**
      *
      * @since 2.3

--- a/adl/test/scenarios/v3/single/output/twitter/models/User.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/models/User.ts
@@ -13,7 +13,7 @@ export interface User {
      * @description Creation time of this user.
      * @since 2.3
      */
-    created_at?: dateTime;
+    created_at?: datetime;
     /**
      * @description The text of this user's profile description (also known as bio), if the user provided one.
      * @since 2.3

--- a/adl/test/scenarios/v3/single/output/twitter/operations/Service.ts
+++ b/adl/test/scenarios/v3/single/output/twitter/operations/Service.ts
@@ -68,7 +68,7 @@ export interface Service {
      * @return 200 - Tweets recent search response
      * @return default - The request has failed.
      */
-    tweetsRecentSearch(query: Query<string & MaxLength<512> & MinLength<1>>, start_time?: Query<dateTime>, end_time?: Query<dateTime>, since_id?: Query<TweetID>, until_id?: Query<TweetID>, max_results?: Query<int32 & Minimum<10> & Maximum<100>>, next_token?: Query<string>, expansions?: TweetExpansionsParameter, tweet_fields?: TweetFieldsParameter, user_fields?: UserFieldsParameter, media_fields?: MediaFieldsParameter, place_fields?: PlaceFieldsParameter, poll_fields?: PollFieldsParameter): [(code: 200, mediaType: "application/json") => {
+    tweetsRecentSearch(query: Query<string & MaxLength<512> & MinLength<1>>, start_time?: Query<datetime>, end_time?: Query<datetime>, since_id?: Query<TweetID>, until_id?: Query<TweetID>, max_results?: Query<int32 & Minimum<10> & Maximum<100>>, next_token?: Query<string>, expansions?: TweetExpansionsParameter, tweet_fields?: TweetFieldsParameter, user_fields?: UserFieldsParameter, media_fields?: MediaFieldsParameter, place_fields?: PlaceFieldsParameter, poll_fields?: PollFieldsParameter): [(code: 200, mediaType: "application/json") => {
         body: TweetSearchResponse;
     }, HttpErrorResponse<"default", true>];
     /**

--- a/documentation/Usage/readme.md
+++ b/documentation/Usage/readme.md
@@ -10,7 +10,7 @@ The following tools are needed to use the ADL CLI and the VSCode extension
 ## Installing ADL tools, and the vscode extension
 Use the NodeJS `npm` tool to install the cli
 
-> `npm install -g @azure-tools\adl`
+> `npm install -g @azure-tools/adl`
 
 ``` text
 + @azure-tools/adl@1.0.179


### PR DESCRIPTION
Out of curiosity, I decided to try `adl import` on a swagger file that I'm using for another project, and I found a trivial bug in the process.

We were emitting `dateTime`, but defined `datetime` as a primitive. This standardizes on `datetime`

This also fixes a slash typo in the usage doc.