### PR TITLE
Update Tests

### DIFF
--- a/adl/language/package.json
+++ b/adl/language/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "prepare": "npm run build",
-    "test": "npm run build && echo - no tests yet mocha dist/test"
+    "test": "mocha -r ts-node/register 'test/**/*.ts'"
   },
   "repository": {
     "type": "git",
@@ -30,15 +30,14 @@
   "homepage": "https://github.com/Azure/adl#readme",
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
-    "mocha": "7.1.2",
-    "@types/node": "12.7.2",
-    "typescript": "~3.9.5",
-    "@testdeck/mocha": "~0.1.0",
     "@types/mocha": "~7.0.2",
+    "@types/node": "^14.0.27",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",
     "eslint": "6.8.0",
-    "@azure-tools/async-io": "~4.0.0"
+    "mocha": "7.1.2",
+    "ts-node": "^8.10.2",
+    "typescript": "~3.9.5"
   },
   "dependencies": {}
 }

--- a/adl/language/test/test-scanner.ts
+++ b/adl/language/test/test-scanner.ts
@@ -56,11 +56,11 @@ describe('scanner', () => {
       [Kind.Whitespace],
       [Kind.Identifier, 'test'],
     ]);
-  })
+  });
 
   /** verifies that this compiled js file parses tokens that are the same as the input.  */
   it('parses this file', async () => {
     const text = await readFile(__filename, 'utf-8');
     const all = tokens(text);
-  })
-})
+  });
+});

--- a/adl/language/test/test-scanner.ts
+++ b/adl/language/test/test-scanner.ts
@@ -1,7 +1,8 @@
-import { readFile } from '@azure-tools/async-io';
-import { suite, test } from '@testdeck/mocha';
 import { strictEqual } from 'assert';
+import { readFile } from 'fs/promises';
+import { describe, it } from 'mocha';
 import { Kind, Scanner } from '../scanner';
+
 
 function tokens(text: string) {
   const scanner = new Scanner(text);
@@ -41,12 +42,9 @@ function verify(tokens: Array<any>, expecting: Array<any>) {
   }
 }
 
-@suite class TestScanner {
-
-
+describe('scanner', () => {
   /** verifies that we can scan tokens and get back some output. */
-  @test 'smoketest'() {
-
+  it('smoketest', () => {
     const all = tokens('\tthis is  a test');
     verify(all, [
       [Kind.Whitespace],
@@ -58,12 +56,11 @@ function verify(tokens: Array<any>, expecting: Array<any>) {
       [Kind.Whitespace],
       [Kind.Identifier, 'test'],
     ]);
-  }
+  })
 
   /** verifies that this compiled js file parses tokens that are the same as the input.  */
-  @test async 'parseThisFile'() {
-    const text = await readFile(__filename);
+  it('parses this file', async () => {
+    const text = await readFile(__filename, 'utf-8');
     const all = tokens(text);
-  }
-
-}
+  })
+})


### PR DESCRIPTION
Prefer using vanilla mocha to class-n'-decorators frameworks. Also since Node 10 we've had promised fs built in, though you need the Node 14 types for it to compile properly.