### PR TITLE
Implement parser

### DIFF
--- a/adl/language/character-codes.ts
+++ b/adl/language/character-codes.ts
@@ -186,8 +186,6 @@ export function isIdentifierPart(ch: number,): boolean {
     ch >= CharacterCodes.a && ch <= CharacterCodes.z ||
     ch >= CharacterCodes._0 && ch <= CharacterCodes._9 ||
     ch === CharacterCodes.$ || ch === CharacterCodes._ ||
-    // "-" and ":" are valid
-    ch === CharacterCodes.minus || ch === CharacterCodes.colon ||
     ch > CharacterCodes.maxAsciiCharacter && isUnicodeIdentifierPart(ch);
 }
 

--- a/adl/language/language.md
+++ b/adl/language/language.md
@@ -122,7 +122,13 @@ EscapeCharacter:
 ``` yaml
 Identifier : IdentifierName but not ReservedWord
 
-ADLScript: 
+ADLScript :
+  StatementList? 
+
+StatementList : 
+  - StatementList? Statement
+
+Statement:
   - ImportStatement+?
   - Declaration+?
 
@@ -133,7 +139,7 @@ ImportStatement:
 
 NamedImports: 
   - Identifier
-  - Identifier `,` NamedImports+
+  - NamedImports `,` Identifier
 
 ScopedIdentifier:
   - Identifier

--- a/adl/language/parser.ts
+++ b/adl/language/parser.ts
@@ -1,7 +1,7 @@
 import { Kind, Scanner } from './scanner';
 
 export function parse(code: string) {
-  const s = new Scanner(code);
+  const scaner = new Scanner(code);
   nextToken();
   return parseADLScript();
 
@@ -13,18 +13,18 @@ export function parse(code: string) {
       end: 0
     };
 
-    while (!s.eof) {
+    while (!scaner.eof) {
       script.statements.push(parseStatement());
     }
 
-    script.end = s.offset;
+    script.end = scaner.offset;
     return script;
   }
 
   function parseStatement(): Statement {
     let decorators = [];
 
-    // eslint-disable-next-line
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       const tok = token();
       let node: Statement;
@@ -400,7 +400,7 @@ export function parse(code: string) {
     if (id !== Kind.Identifier) {
       error(`expected an identifier, got ${Kind[id]}`);
     }
-    const sv = s.value;
+    const sv = scaner.value;
 
     nextToken();
 
@@ -413,23 +413,23 @@ export function parse(code: string) {
 
   // utility functions
   function token() {
-    return s.token;
+    return scaner.token;
   }
 
   function tokenValue() {
-    return s.value;
+    return scaner.value;
   }
 
   function tokenPos() {
-    return s.offset;
+    return scaner.offset;
   }
 
   function nextToken() {
-    s.scan();
+    scaner.scan();
 
     // skip whitespace tokens for now
     while (token() === Kind.Whitespace || token() === Kind.NewLine) {
-      s.scan();
+      scaner.scan();
     }
   }
 
@@ -442,7 +442,7 @@ export function parse(code: string) {
   }
 
   function error(msg: string) {
-    throw new Error(`[${s.position.line}, ${s.position.character}] ${msg}`);
+    throw new Error(`[${scaner.position.line}, ${scaner.position.character}] ${msg}`);
   }
 
   function parseExpected(expectedToken: Kind) {

--- a/adl/language/parser.ts
+++ b/adl/language/parser.ts
@@ -63,12 +63,12 @@ export function parse(code: string) {
     const properties: Array<InterfacePropertyNode> = [];
 
     if (parseOptional(Kind.CloseBrace)) {
-      return <any>finishNode({
-        type: 'InterfaceStatement',
+      return finishNode({
+        kind: SyntaxKind.InterfaceStatement,
         decorators,
         id,
         properties
-      }, pos); // todo: 😠
+      }, pos);
     }
 
     let memberDecorators: Array<DecoratorExpressionNode> = [];
@@ -157,7 +157,7 @@ export function parse(code: string) {
       return <any>finishNode({
         ...node,
         properties
-      }, pos); // todo: 😠
+      }, pos);
     }
 
     let memberDecorators: Array<DecoratorExpressionNode> = [];
@@ -174,7 +174,7 @@ export function parse(code: string) {
     return <any>finishNode({
       ...node,
       properties,
-    }, pos); // todo: 😠
+    }, pos);
   }
 
   function parseModelProperty(decorators: Array<DecoratorExpressionNode>): ModelPropertyNode {

--- a/adl/language/parser.ts
+++ b/adl/language/parser.ts
@@ -1,4 +1,4 @@
-import { Kind, Scanner } from './scanner.js';
+import { Kind, Scanner } from './scanner';
 
 export function parse(code: string) {
   const s = new Scanner(code);

--- a/adl/language/parser.ts
+++ b/adl/language/parser.ts
@@ -1,0 +1,596 @@
+import { Kind, Scanner } from './scanner.js';
+
+export function parse(code: string) {
+  const s = new Scanner(code);
+  nextToken();
+  return parseADLScript();
+
+  function parseADLScript(): ADLScriptNode {
+    const script: ADLScriptNode = {
+      kind: SyntaxKind.ADLScript,
+      statements: [],
+      pos: 0,
+      end: 0
+    }
+
+    while (!s.eof) {
+      script.statements.push(parseStatement());
+    }
+
+    script.end = s.offset;
+    return script;
+  }
+
+  function parseStatement(): Statement {
+    let decorators = [];
+    while (true) {
+      const tok = token();
+      switch (tok) {
+        case Kind.ImportKeyword:
+          if (decorators.length > 0) {
+            error('Cannot decorate an import statement');
+          }
+          return parseImportStatement();
+        case Kind.At:
+          decorators.push(parseDecoratorExpression());
+          continue;
+        case Kind.ModelKeyword:
+          const model = parseModelStatement(decorators);
+          decorators = [];
+          return model;
+        case Kind.InterfaceKeyword:
+          const iface = parseInterfaceStatement(decorators);
+          decorators = [];
+          return iface;
+      }
+
+      throw new Error('Unable to parse statement');
+    }
+
+  }
+
+  function parseInterfaceStatement(
+    decorators: DecoratorExpressionNode[]
+  ): InterfaceStatementNode {
+    const pos = tokenPos();
+    parseExpected(Kind.InterfaceKeyword);
+    const id = parseIdentifier();
+    parseExpected(Kind.OpenBrace);
+    const properties: InterfacePropertyNode[] = [];
+
+    if (parseOptional(Kind.CloseBrace)) {
+      return finishNode({
+        type: "InterfaceStatement",
+        decorators,
+        id,
+        properties
+      }, pos) as any; // todo: 😠
+    }
+
+    let memberDecorators: DecoratorExpressionNode[] = [];
+    do {
+      if (token() === Kind.At) {
+        memberDecorators.push(parseDecoratorExpression());
+      }
+      properties.push(parseInterfaceProperty(memberDecorators));
+      memberDecorators = [];
+    } while (parseOptional(Kind.Comma))
+
+    parseExpected(Kind.CloseBrace)
+
+    return finishNode({
+      kind: SyntaxKind.InterfaceStatement,
+      decorators,
+      id,
+      properties
+    }, pos);
+  }
+
+  function parseInterfaceProperty(decorators: DecoratorExpressionNode[]): InterfacePropertyNode {
+    const pos = tokenPos();
+    const id = parseIdentifier();
+    const parameters = parseParameterList();
+    parseExpected(Kind.Colon);
+    const returnType = parseExpression();
+
+    return finishNode({
+      kind: SyntaxKind.InterfaceProperty,
+      id,
+      parameters,
+      returnType,
+      decorators
+    }, pos);
+  }
+
+  function parseParameterList(): InterfaceParameterNode[] {
+    parseExpected(Kind.OpenParen);
+
+    if (parseOptional(Kind.CloseParen)) {
+      return [];
+    }
+    const params: InterfaceParameterNode[] = [];
+    do {
+      const pos = tokenPos();
+      const id = parseIdentifier();
+      const optional = parseOptional(Kind.Question);
+      parseExpected(Kind.Colon);
+      const value = parseExpression();
+
+      params.push(finishNode({
+        kind: SyntaxKind.InterfaceParameter,
+        id,
+        value,
+        optional
+      }, pos));
+    } while (parseOptional(Kind.Comma))
+    parseExpected(Kind.CloseParen);
+    return params;
+  }
+
+  function parseModelStatement(
+    decorators: DecoratorExpressionNode[]
+  ): ModelStatementNode {
+    const pos = tokenPos();
+    parseExpected(Kind.ModelKeyword);
+    const id = parseIdentifier();
+    parseExpected(Kind.OpenBrace);
+    const node: Partial<ModelStatementNode> = {
+      kind: SyntaxKind.ModelStatement,
+      id,
+      decorators
+    };
+
+    return finishModel(pos, node);
+  }
+
+  function finishModel<T extends ModelStatementNode | ModelExpressionNode>(
+    pos: number,
+    node: Partial<T>
+  ): T {
+    const properties: ModelPropertyNode[] = [];
+
+    if (parseOptional(Kind.CloseBrace)) {
+      return finishNode({
+        ...node,
+        properties
+      }, pos) as any; // todo: 😠
+    }
+
+    let memberDecorators: DecoratorExpressionNode[] = [];
+    do {
+      if (token() === Kind.At) {
+        memberDecorators.push(parseDecoratorExpression());
+      }
+      properties.push(parseModelProperty(memberDecorators));
+      memberDecorators = [];
+    } while (parseOptional(Kind.Comma))
+
+    parseExpected(Kind.CloseBrace)
+
+    return finishNode({
+      ...node,
+      properties,
+    }, pos) as any;
+  }
+
+  function parseModelProperty(decorators: DecoratorExpressionNode[]): ModelPropertyNode {
+    const pos = tokenPos();
+    let id: IdentifierNode | StringLiteralNode;
+    switch (token()) {
+      case Kind.Identifier:
+        id = parseIdentifier();
+        break;
+      case Kind.StringLiteral:
+        id = parseStringLiteral();
+        break;
+      default:
+        throw error('expected identifier or string literal');
+    }
+
+    const optional = parseOptional(Kind.Question);
+    parseExpected(Kind.Colon);
+    const value = parseExpression();
+
+    return finishNode({
+      kind: SyntaxKind.ModelProperty,
+      id,
+      decorators,
+      value,
+      optional
+    }, pos);
+  }
+
+  function parseExpression(): Expression {
+    return parseUnionExpression();
+  }
+
+  function parseUnionExpression(): Expression {
+    let node = parseArrayExpression();
+
+    if (token() !== Kind.Bar) {
+      return node;
+    }
+
+    node = {
+      kind: SyntaxKind.UnionExpression,
+      options: [node]
+    }
+
+    while (parseOptional(Kind.Bar)) {
+      const expr = parseArrayExpression();
+      node.options.push(expr);
+    }
+
+    return node;
+  }
+
+  function parseArrayExpression(): Expression {
+    const pos = tokenPos();
+    const expr = parseMemberExpression();
+
+    if (token() !== Kind.OpenBracket) {
+      return expr;
+    }
+    parseExpected(Kind.OpenBracket);
+    parseExpected(Kind.CloseBracket);
+
+    const arr: ArrayExpressionNode = finishNode({
+      kind: SyntaxKind.ArrayExpression,
+      elementType: expr
+    }, pos);
+
+    return arr as any;
+  }
+
+  function parseImportStatement(): ImportStatementNode {
+    const pos = tokenPos();
+
+    parseExpected(Kind.ImportKeyword);
+    const id = parseIdentifier();
+    let as: NamedImportNode[] = [];
+
+    if (token() === Kind.Identifier && tokenValue() === 'as') {
+      parseExpected(Kind.Identifier);
+      parseExpected(Kind.OpenBrace);
+
+      if (token() !== Kind.CloseBrace) {
+        as = parseNamedImports();
+      }
+
+      parseExpected(Kind.CloseBrace);
+    }
+
+    parseExpected(Kind.Semicolon);
+    return finishNode({
+      kind: SyntaxKind.ImportStatement,
+      as, id
+    }, pos);
+  }
+
+  function parseNamedImports(): NamedImportNode[] {
+    const names: NamedImportNode[] = [];
+    do {
+      const pos = tokenPos();
+      names.push(finishNode({
+        kind: SyntaxKind.NamedImport,
+        id: parseIdentifier()
+      }, pos));
+    } while (parseOptional(Kind.Comma))
+    return names;
+  }
+
+  function parseDecoratorExpression(): DecoratorExpressionNode {
+    const pos = tokenPos();
+    parseExpected(Kind.At);
+    const target = parseMemberExpression();
+
+    if (target.kind !== SyntaxKind.Identifier
+      && target.kind !== SyntaxKind.MemberExpression) {
+      throw error(`a ${target.kind} is not a valid decorator`);
+    }
+
+    let args: Expression[] = [];
+    if (parseOptional(Kind.OpenParen)) {
+      if (!parseOptional(Kind.CloseParen)) {
+        args = parseExpressionList();
+        parseExpected(Kind.CloseParen);
+      }
+    }
+
+    return finishNode({
+      kind: SyntaxKind.DecoratorExpression,
+      arguments: args,
+      target
+    }, pos);
+  }
+
+  function parseExpressionList(): Expression[] {
+    const args: Expression[] = [];
+
+    do {
+      args.push(parseExpression());
+    } while (parseOptional(Kind.Comma));
+
+    return args;
+  }
+
+  function parseMemberExpression(): Expression {
+    let base: Expression = parsePrimaryExpression();
+
+    while (parseOptional(Kind.Dot)) {
+      if (token() !== Kind.Identifier) {
+        error('Member expressions only apply to identifiers');
+      }
+      const pos = tokenPos();
+      base = finishNode({
+        kind: SyntaxKind.MemberExpression,
+        base,
+        id: parseIdentifier()
+      }, pos);
+    }
+
+    return base;
+  }
+
+  function parsePrimaryExpression(): Expression {
+    switch (token()) {
+      case Kind.Identifier: return parseIdentifier();
+      case Kind.StringLiteral: return parseStringLiteral();
+      case Kind.NumericLiteral: return parseNumericLiteral();
+      case Kind.OpenBrace: return parseModelExpression([]);
+      case Kind.OpenBracket: return parseTupleExpression();
+    }
+
+    throw error(`Unexpected token: ${Kind[token()]}`);
+  }
+
+  function parseTupleExpression(): TupleExpressionNode {
+    const pos = tokenPos();
+    parseExpected(Kind.OpenBracket);
+    const values = parseExpressionList();
+    parseExpected(Kind.CloseBracket);
+    return finishNode({
+      kind: SyntaxKind.TupleExpression,
+      values
+    }, pos);
+  }
+
+  function parseModelExpression(decorators: DecoratorExpressionNode[]): ModelExpressionNode {
+    const pos = tokenPos();
+    parseExpected(Kind.OpenBrace);
+    const node: Partial<ModelExpressionNode> = {
+      kind: SyntaxKind.ModelExpression,
+      decorators
+    };
+
+    return finishModel(pos, node);
+  }
+
+  function parseStringLiteral(): StringLiteralNode {
+    const pos = tokenPos();
+    const value = tokenValue();
+    parseExpected(Kind.StringLiteral);
+    return finishNode({
+      kind: SyntaxKind.StringLiteral,
+      value
+    }, pos);
+  }
+
+  function parseNumericLiteral(): NumericLiteralNode {
+    const pos = tokenPos();
+    const value = tokenValue();
+    parseExpected(Kind.NumericLiteral);
+    return finishNode({
+      kind: SyntaxKind.NumericLiteral,
+      value
+    }, pos);
+  }
+
+  function parseIdentifier(): IdentifierNode {
+    const id = token();
+    const pos = tokenPos();
+
+    if (id !== Kind.Identifier) {
+      error(`expected an identifier, got ${Kind[id]}`);
+    }
+    const sv = s.value;
+
+    nextToken();
+
+    return finishNode({
+      kind: SyntaxKind.Identifier,
+      sv
+    }, pos);
+  }
+
+
+  // utility functions
+  function token() {
+    return s.token;
+  }
+
+  function tokenValue() {
+    return s.value;
+  }
+
+  function tokenPos() {
+    return s.offset;
+  }
+
+  function nextToken() {
+    s.scan();
+
+    // skip whitespace tokens for now
+    while (token() === Kind.Whitespace || token() === Kind.NewLine) {
+      s.scan();
+    }
+  }
+
+  function finishNode<T>(o: T, pos: number): T & { pos: number, end: number } {
+    return {
+      ...o,
+      pos,
+      end: tokenPos()
+    }
+  }
+
+  function error(msg: string) {
+    throw new Error(`[${s.position.line}, ${s.position.character}] ${msg}`);
+  }
+
+  function parseExpected(expectedToken: Kind) {
+    if (token() === expectedToken) {
+      nextToken();
+      return true;
+    } else {
+      error(`expected ${Kind[expectedToken]}, got ${Kind[token()]}`);
+      return false;
+    }
+  }
+
+  function parseOptional(optionalToken: Kind) {
+    if (token() === optionalToken) {
+      nextToken();
+      return true;
+    }
+
+    return false;
+  }
+}
+
+export enum SyntaxKind {
+  ADLScript,
+  ImportStatement,
+  Identifier,
+  NamedImport,
+  DecoratorExpression,
+  MemberExpression,
+  InterfaceStatement,
+  InterfaceProperty,
+  InterfaceParameter,
+  ModelStatement,
+  ModelExpression,
+  ModelProperty,
+  UnionExpression,
+  TupleExpression,
+  ArrayExpression,
+  StringLiteral,
+  NumericLiteral
+}
+
+export interface Node {
+  kind: SyntaxKind,
+  pos: number,
+  end: number
+}
+
+export interface ADLScriptNode extends Node {
+  kind: SyntaxKind.ADLScript;
+  statements: Array<Statement>;
+}
+
+export type Statement = ImportStatementNode | ModelStatementNode | InterfaceStatementNode;
+
+export interface ImportStatementNode extends Node {
+  kind: SyntaxKind.ImportStatement;
+  id: IdentifierNode;
+  as: Array<NamedImportNode>;
+}
+
+export interface IdentifierNode extends Node {
+  kind: SyntaxKind.Identifier;
+  sv: string;
+}
+
+interface NamedImportNode extends Node {
+  kind: SyntaxKind.NamedImport;
+  id: IdentifierNode;
+}
+
+interface DecoratorExpressionNode extends Node {
+  kind: SyntaxKind.DecoratorExpression,
+  target: IdentifierNode | MemberExpressionNode,
+  arguments: Expression[]
+}
+
+type Expression =
+  | MemberExpressionNode
+  | ModelExpressionNode
+  | TupleExpressionNode
+  | UnionExpressionNode
+  | IdentifierNode
+  | StringLiteralNode
+  | NumericLiteralNode;
+
+interface MemberExpressionNode extends Node {
+  kind: SyntaxKind.MemberExpression,
+  id: IdentifierNode,
+  base: Expression | IdentifierNode
+}
+
+export interface InterfaceStatementNode extends Node {
+  kind: SyntaxKind.InterfaceStatement,
+  id: IdentifierNode,
+  properties: InterfacePropertyNode[],
+  decorators: DecoratorExpressionNode[]
+}
+
+export interface InterfacePropertyNode extends Node {
+  kind: SyntaxKind.InterfaceProperty,
+  id: IdentifierNode,
+  parameters: InterfaceParameterNode[],
+  returnType: Expression,
+  decorators: DecoratorExpressionNode[]
+}
+
+export interface InterfaceParameterNode extends Node {
+  kind: SyntaxKind.InterfaceParameter,
+  id: IdentifierNode,
+  value: Expression,
+  optional: boolean
+}
+
+export interface ModelStatementNode extends Node {
+  kind: SyntaxKind.ModelStatement,
+  id: IdentifierNode,
+  properties: ModelPropertyNode[],
+  decorators: DecoratorExpressionNode[],
+}
+
+export interface ModelExpressionNode extends Node {
+  kind: SyntaxKind.ModelExpression,
+  properties: ModelPropertyNode[],
+  decorators: DecoratorExpressionNode[],
+}
+
+export interface ArrayExpressionNode extends Node {
+  kind: SyntaxKind.ArrayExpression,
+  elementType: Expression
+}
+export interface TupleExpressionNode extends Node {
+  kind: SyntaxKind.TupleExpression,
+  values: Expression[]
+}
+
+export interface ModelPropertyNode extends Node {
+  kind: SyntaxKind.ModelProperty,
+  id: IdentifierNode | StringLiteralNode,
+  value: Expression,
+  decorators: DecoratorExpressionNode[],
+  optional: boolean
+}
+
+export interface StringLiteralNode extends Node {
+  kind: SyntaxKind.StringLiteral,
+  value: string
+}
+
+export interface NumericLiteralNode extends Node {
+  kind: SyntaxKind.NumericLiteral,
+  value: string
+}
+
+export interface UnionExpressionNode extends Node {
+  kind: SyntaxKind.UnionExpression,
+  options: Expression[]
+}

--- a/adl/language/scanner.ts
+++ b/adl/language/scanner.ts
@@ -1,5 +1,5 @@
-import { CharacterCodes, isBinaryDigit, isDigit, isHexDigit, isIdentifierPart, isIdentifierStart, isLineBreak, isWhiteSpaceSingleLine, sizeOf } from './character-codes.js';
-import { format, Message, messages } from './messages.js';
+import { CharacterCodes, isBinaryDigit, isDigit, isHexDigit, isIdentifierPart, isIdentifierStart, isLineBreak, isWhiteSpaceSingleLine, sizeOf } from './character-codes';
+import { format, Message, messages } from './messages';
 
 // All conflict markers consist of the same character repeated seven times.  If it is
 // a <<<<<<< or >>>>>>> marker then it is also followed by a space.

--- a/adl/language/scanner.ts
+++ b/adl/language/scanner.ts
@@ -696,7 +696,7 @@ export class Scanner {
   positionFromOffset(offset: number): Position {
     let position = { line: 0, character: 0, offset: 0 };
 
-    // eslint-disable-next-line
+    // eslint-disable-next-line keyword-spacing
     if (offset < 0 || offset > this.#length) {
       return { line: position.line, character: position.character };
     }

--- a/adl/language/scanner.ts
+++ b/adl/language/scanner.ts
@@ -1,5 +1,5 @@
-import { CharacterCodes, isBinaryDigit, isDigit, isHexDigit, isIdentifierPart, isIdentifierStart, isLineBreak, isWhiteSpaceSingleLine, sizeOf } from './character-codes';
-import { format, Message, messages } from './messages';
+import { CharacterCodes, isBinaryDigit, isDigit, isHexDigit, isIdentifierPart, isIdentifierStart, isLineBreak, isWhiteSpaceSingleLine, sizeOf } from './character-codes.js';
+import { format, Message, messages } from './messages.js';
 
 // All conflict markers consist of the same character repeated seven times.  If it is
 // a <<<<<<< or >>>>>>> marker then it is also followed by a space.
@@ -120,7 +120,18 @@ export enum Kind {
 
   // Identifiers
   Identifier,
+
+  // Keywords
+  ImportKeyword,
+  ModelKeyword,
+  InterfaceKeyword
 }
+
+const keywords = new Map([
+  ['import', Kind.ImportKeyword],
+  ['model', Kind.ModelKeyword],
+  ['interface', Kind.InterfaceKeyword]
+]);
 
 interface TokenLocation extends Position {
   offset: number;
@@ -574,7 +585,7 @@ export class Scanner {
 
     // update the position
     this.#column += (this.#offset - start);
-    return Kind.NumericLiteral;
+    return this.token = Kind.NumericLiteral;
   }
 
   private scanHexNumber() {
@@ -674,7 +685,7 @@ export class Scanner {
 
   scanIdentifier() {
     this.value = this.scanUntil((ch) => !isIdentifierPart(ch));
-    return this.token = Kind.Identifier;
+    return this.token = keywords.get(this.value) ?? Kind.Identifier;
   }
 
   /**
@@ -684,7 +695,7 @@ export class Scanner {
    */
   positionFromOffset(offset: number): Position {
     let position = { line: 0, character: 0, offset: 0 };
-    if (offset < 0 || offset >this.#length) {
+    if (offset < 0 || offset > this.#length) {
       return { line: position.line, character: position.character };
     }
 

--- a/adl/language/scanner.ts
+++ b/adl/language/scanner.ts
@@ -696,7 +696,7 @@ export class Scanner {
   positionFromOffset(offset: number): Position {
     let position = { line: 0, character: 0, offset: 0 };
 
-    // eslint-disable-line
+    // eslint-disable-next-line
     if (offset < 0 || offset > this.#length) {
       return { line: position.line, character: position.character };
     }

--- a/adl/language/scanner.ts
+++ b/adl/language/scanner.ts
@@ -695,6 +695,8 @@ export class Scanner {
    */
   positionFromOffset(offset: number): Position {
     let position = { line: 0, character: 0, offset: 0 };
+
+    // eslint-disable-line
     if (offset < 0 || offset > this.#length) {
       return { line: position.line, character: position.character };
     }

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -1,18 +1,19 @@
-import { parse } from '../parser.js';
-const { describe, it } = require('mocha');
+import { describe, it } from 'mocha';
+import { parse } from '../parser';
+
 describe('syntax', () => {
   describe('import statements', () => {
     parseEach([
-      `import x;`,
-      `import x as { one };`,
-      `import x as {};`,
-      `import x as { one, two };`
-    ])
-  })
+      'import x;',
+      'import x as { one };',
+      'import x as {};',
+      'import x as { one, two };'
+    ]);
+  });
 
   describe('model statements', () => {
     parseEach([
-      `model Car { };`,
+      'model Car { };',
 
       `@foo()
        model Car { };`,
@@ -38,45 +39,45 @@ describe('syntax', () => {
          prop2: string
        };`,
 
-      `model Foo { "strKey": number, "😂😂😂": string }`
-    ])
-  })
+      'model Foo { "strKey": number, "😂😂😂": string }'
+    ]);
+  });
 
   describe('model expressions', () => {
     parseEach([
-      `model Car { engine: { type: "v8" } }`
+      'model Car { engine: { type: "v8" } }'
     ]);
-  })
+  });
 
   describe('tuple model expressions', () => {
     parseEach([
-      `interface A { b(param: [number, string]): [1, "hi"] }`
-    ])
-  })
+      'interface A { b(param: [number, string]): [1, "hi"] }'
+    ]);
+  });
 
   describe('array expressions', () => {
     parseEach([
-      `model A { foo: B[] }`
-    ])
-  })
+      'model A { foo: B[] }'
+    ]);
+  });
 
   describe('union expressions', () => {
     parseEach([
-      `model A { foo: B | C }`
-    ])
-  })
+      'model A { foo: B | C }'
+    ]);
+  });
 
   describe('interface statements', () => {
     parseEach([
-      `interface Store { read(): int32 }`,
-      `interface Store { read(): int32, write(v: int32): {}`,
-      `@foo interface Store { @dec read():number, @dec write(n: number): {} }`
+      'interface Store { read(): int32 }',
+      'interface Store { read(): int32, write(v: int32): {}',
+      '@foo interface Store { @dec read():number, @dec write(n: number): {} }'
     ]);
-  })
+  });
 
-})
+});
 
-function parseEach(cases: string[]) {
+function parseEach(cases: Array<string>) {
   for (const code of cases) {
     it('parses `' + shorten(code) + '`', () => {
       dumpAST(parse(code));

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -1,0 +1,93 @@
+import { parse } from '../parser.js';
+const { describe, it } = require('mocha');
+describe('syntax', () => {
+  describe('import statements', () => {
+    parseEach([
+      `import x;`,
+      `import x as { one };`,
+      `import x as {};`,
+      `import x as { one, two };`
+    ])
+  })
+
+  describe('model statements', () => {
+    parseEach([
+      `model Car { };`,
+
+      `@foo()
+       model Car { };`,
+
+      `model Car {
+         prop1: number,
+         prop2: string
+       };`,
+
+      `model Car {
+          engine: V6
+        }
+        
+        model V6 {
+          name: string
+        }`,
+
+      `model Car {
+         @foo.bar(a, b)
+         prop1: number,
+         
+         @foo.baz(10, "hello")
+         prop2: string
+       };`,
+
+      `model Foo { "strKey": number, "😂😂😂": string }`
+    ])
+  })
+
+  describe('model expressions', () => {
+    parseEach([
+      `model Car { engine: { type: "v8" } }`
+    ]);
+  })
+
+  describe('tuple model expressions', () => {
+    parseEach([
+      `interface A { b(param: [number, string]): [1, "hi"] }`
+    ])
+  })
+
+  describe('array expressions', () => {
+    parseEach([
+      `model A { foo: B[] }`
+    ])
+  })
+
+  describe('union expressions', () => {
+    parseEach([
+      `model A { foo: B | C }`
+    ])
+  })
+
+  describe('interface statements', () => {
+    parseEach([
+      `interface Store { read(): int32 }`,
+      `interface Store { read(): int32, write(v: int32): {}`,
+      `@foo interface Store { @dec read():number, @dec write(n: number): {} }`
+    ]);
+  })
+
+})
+
+function parseEach(cases: string[]) {
+  for (const code of cases) {
+    it('parses `' + shorten(code) + '`', () => {
+      dumpAST(parse(code));
+    });
+  }
+}
+
+function dumpAST(astNode: any) {
+  console.log(JSON.stringify(astNode, null, 4));
+}
+
+function shorten(code: string) {
+  return code.replace(/\s+/g, ' ');
+}

--- a/adl/language/test/test-scanner.ts
+++ b/adl/language/test/test-scanner.ts
@@ -3,11 +3,11 @@ import { readFile } from 'fs/promises';
 import { describe, it } from 'mocha';
 import { Kind, Position, Scanner } from '../scanner';
 
-type TokenEntry = [Kind, string?, "error"?, Position?];
+type TokenEntry = [Kind, string?, 'error'?, Position?];
 
-function tokens(text: string): TokenEntry[] {
+function tokens(text: string): Array<TokenEntry> {
   const scanner = new Scanner(text);
-  const result: TokenEntry[] = [];
+  const result: Array<TokenEntry> = [];
   do {
     const token = scanner.scan();
     result.push([
@@ -31,7 +31,7 @@ function dump(tokens: Array<any>) {
 }
 
 
-function verify(tokens: TokenEntry[], expecting: TokenEntry[]) {
+function verify(tokens: Array<TokenEntry>, expecting: Array<TokenEntry>) {
   for (const [index, [expectedToken, expectedValue]] of expecting.entries()) {
     const [token, value] = tokens[index];
     strictEqual(Kind[token], Kind[expectedToken], `Token ${index} must match`);
@@ -70,24 +70,24 @@ describe('scanner', () => {
       [Kind.Colon],
       [Kind.Identifier, 'y'],
       [Kind.CloseBrace]
-    ])
-  })
+    ]);
+  });
 
   it('scans decorator expressions', () => {
     const all = tokens('@foo(1,"hello",foo)');
 
     verify(all, [
       [Kind.At],
-      [Kind.Identifier, "foo"],
+      [Kind.Identifier, 'foo'],
       [Kind.OpenParen],
-      [Kind.NumericLiteral, "1"],
+      [Kind.NumericLiteral, '1'],
       [Kind.Comma],
       [Kind.StringLiteral, '"hello"'],
       [Kind.Comma],
       [Kind.Identifier],
       [Kind.CloseParen]
-    ])
-  })
+    ]);
+  });
   /** verifies that this compiled js file parses tokens that are the same as the input.  */
   it('parses this file', async () => {
     const text = await readFile(__filename, 'utf-8');


### PR DESCRIPTION
This is a quick 'n dirty pass at implementing a parser for the grammar found in language.md.

There are some deltas with what was discussed last week:
* `@` is used for decorators rather than `[`/`]`. This is just an aesthetic preference.
* `.` is used for member access rather than `:`. Also an aesthetic preference.
* Implemented unions (`|`), tuples (`[...]`) and array types (`id[]`)
* The other changes should be fixes.