### PR TITLE
Implement square-bracket decorators

### DIFF
--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -39,6 +39,16 @@ describe('syntax', () => {
          prop2: string
        };`,
 
+      `
+      [Foo()]
+      model Car {
+         [Foo.bar(10, "hello")]
+         prop1: number,
+         
+         [Foo.baz(a, b)]
+         prop2: string
+       };`,
+
       'model Foo { "strKey": number, "😂😂😂": string }'
     ]);
   });


### PR DESCRIPTION
This supports square-bracket style decorators/annotations in addition to the `@` style. Easy to support both syntaxes, for now, with the same node shapes even. So, use what you like 😁