### PR TITLE
Allow semicolons as member separators

### DIFF
--- a/adl/language/parser.ts
+++ b/adl/language/parser.ts
@@ -63,23 +63,18 @@ export function parse(code: string) {
     parseExpected(Kind.OpenBrace);
     const properties: Array<InterfacePropertyNode> = [];
 
-    if (parseOptional(Kind.CloseBrace)) {
-      return finishNode({
-        kind: SyntaxKind.InterfaceStatement,
-        decorators,
-        id,
-        properties
-      }, pos);
-    }
 
     let memberDecorators: Array<DecoratorExpressionNode> = [];
     do {
+      if (token() == Kind.CloseBrace) {
+        break;
+      }
       if (token() === Kind.At || token() === Kind.OpenBracket) {
         memberDecorators.push(parseDecoratorExpression());
       }
       properties.push(parseInterfaceProperty(memberDecorators));
       memberDecorators = [];
-    } while (parseOptional(Kind.Comma));
+    } while (parseOptional(Kind.Comma) || parseOptional(Kind.Semicolon));
 
     parseExpected(Kind.CloseBrace);
 
@@ -152,18 +147,17 @@ export function parse(code: string) {
   function parseModelPropertyList(): Array<ModelPropertyNode> {
     const properties: Array<ModelPropertyNode> = [];
 
-    if (parseOptional(Kind.CloseBrace)) {
-      return properties;
-    }
-
     let memberDecorators: Array<DecoratorExpressionNode> = [];
     do {
+      if (token() == Kind.CloseBrace) {
+        break;
+      }
       if (token() === Kind.At || token() === Kind.OpenBracket) {
         memberDecorators.push(parseDecoratorExpression());
       }
       properties.push(parseModelProperty(memberDecorators));
       memberDecorators = [];
-    } while (parseOptional(Kind.Comma));
+    } while (parseOptional(Kind.Comma) || parseOptional(Kind.Semicolon));
 
     parseExpected(Kind.CloseBrace);
     return properties;

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -24,6 +24,11 @@ describe('syntax', () => {
        };`,
 
       `model Car {
+         prop1: number;
+         prop2: string;
+       }`,
+
+      `model Car {
           engine: V6
         }
         
@@ -79,8 +84,10 @@ describe('syntax', () => {
 
   describe('interface statements', () => {
     parseEach([
+      'interface Store {}',
       'interface Store { read(): int32 }',
       'interface Store { read(): int32, write(v: int32): {}',
+      'interface Store { read(): int32; write(v: int32): {}',
       '@foo interface Store { @dec read():number, @dec write(n: number): {} }'
     ]);
   });


### PR DESCRIPTION
Allow semicolons between interface and model members, and allow trialing commas and semicolons after interface and model members.

Also, in separate initial commit, refactor a bit to avoid having to cast to any.
