### PR TITLE
Fix official build

### DIFF
--- a/adl/.template/package.json
+++ b/adl/.template/package.json
@@ -31,7 +31,7 @@
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
     "mocha": "7.1.1",
-    "@types/node": "12.7.2",
+    "@types/node": "14.0.27",
     "typescript": "~3.8.3",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",

--- a/adl/cli/package.json
+++ b/adl/cli/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/Azure/adl#readme",
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
-    "@types/node": "12.7.2",
+    "@types/node": "14.0.27",
     "@types/marked": "0.3.0",
     "mocha": "7.1.2",
     "typescript": "~3.9.5",

--- a/adl/core/package.json
+++ b/adl/core/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/Azure/adl#readme",
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
-    "@types/node": "12.7.2",
+    "@types/node": "14.0.27",
     "mocha": "7.1.2",
     "@types/mocha": "~7.0.2",
     "@typescript-eslint/eslint-plugin": "2.28.0",

--- a/adl/core/plugin/export-from-plugin.ts
+++ b/adl/core/plugin/export-from-plugin.ts
@@ -18,8 +18,7 @@ export function exportFromPlugin(container: string, location: string, result: an
     // and added to the map
     if (name.endsWith('.js')) {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const mod = require.cache[fullPath] ? require.cache[fullPath].exports : require(fullPath);
+        const mod = require.cache[fullPath]?.exports ?? require(fullPath);
 
         if (mod.default) {
           // files with a default export are added to the tree.

--- a/adl/extension/package.json
+++ b/adl/extension/package.json
@@ -63,7 +63,7 @@
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
     "@types/mocha": "~7.0.2",
-    "@types/node": "12.7.2",
+    "@types/node": "14.0.27",
     "@types/vscode": "~1.45.0",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",

--- a/adl/language/package.json
+++ b/adl/language/package.json
@@ -31,7 +31,7 @@
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
     "@types/mocha": "~7.0.2",
-    "@types/node": "^14.0.27",
+    "@types/node": "14.0.27",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",
     "eslint": "6.8.0",

--- a/adl/plugins/arm/package.json
+++ b/adl/plugins/arm/package.json
@@ -31,7 +31,7 @@
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
     "mocha": "7.1.2",
-    "@types/node": "12.7.2",
+    "@types/node": "14.0.27",
     "typescript": "~3.9.5",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",

--- a/adl/plugins/azure/package.json
+++ b/adl/plugins/azure/package.json
@@ -30,7 +30,7 @@
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
     "mocha": "7.1.2",
-    "@types/node": "12.7.2",
+    "@types/node": "14.0.27",
     "typescript": "~3.9.5",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@azure-tools/linq": "~4.0.0",

--- a/adl/plugins/core/package.json
+++ b/adl/plugins/core/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",
     "eslint": "6.8.0",
-    "@types/node": "12.7.2",
+    "@types/node": "14.0.27",
     "@azure-tools/adl.core": "~0.1.0"
   }
 }

--- a/adl/plugins/sample/package.json
+++ b/adl/plugins/sample/package.json
@@ -31,7 +31,7 @@
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
     "mocha": "7.1.2",
-    "@types/node": "12.7.2",
+    "@types/node": "14.0.27",
     "typescript": "~3.9.5",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",

--- a/adl/sourcemap/package.json
+++ b/adl/sourcemap/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/Azure/adl#readme",
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
-    "@types/node": "12.7.2",
+    "@types/node": "14.0.27",
     "mocha": "7.1.2",
     "@types/mocha": "~7.0.2",
     "typescript": "~3.9.5",

--- a/documentation/Usage/readme.md
+++ b/documentation/Usage/readme.md
@@ -4,7 +4,7 @@
 
 The following tools are needed to use the ADL CLI and the VSCode extension
 
-  - NodeJS 12+ (NodeJS 14+ has better perf, but 12 should do)
+  - NodeJS 14+
   - VSCode 
 
 ## Installing ADL tools, and the vscode extension

--- a/instructions.md
+++ b/instructions.md
@@ -1,7 +1,7 @@
 # Build Instructions
 
 Prerequisites: 
-1. [Node.js](https://nodejs.org/en/download/) (>=10.13.0 <15.0.0)
+1. [Node.js](https://nodejs.org/en/download/) (>=14.0.0 <15.0.0)
 
 2. [Rush](https://rushjs.io/pages/intro/welcome/) 
 

--- a/rush.json
+++ b/rush.json
@@ -10,7 +10,7 @@
    * Options that are only used when the PNPM package manager is selected
    */
   "pnpmOptions": {},
-  "nodeSupportedVersionRange": ">=10.13.0 <15.0.0",
+  "nodeSupportedVersionRange": ">=14.0.0 <15.0.0",
   "suppressNodeLtsWarning": true,
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 5,


### PR DESCRIPTION
I'm not exactly sure what is going on here, but the official build [started failing](
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=487678&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=9c939e41-62c2-5605-5e05-fc3554afc9f5&l=388) when the test project got updated to @types/node 14. Somehow an error that only triggers when the core project use @types/node 14 started failing. When I upgraded every project to @types/node 14, I saw the error locally. 

Why is there cross-talk between project packages, but only in the official build, not in PR validation?

I'm not sure if this is an OK fix, but I've put @types/node 14 in all projects and fixed the error about a possible null ref.
