### PR TITLE
Parse model equals

### DIFF
--- a/adl/language/language.md
+++ b/adl/language/language.md
@@ -236,9 +236,14 @@ AdditionalTemplateArguments: `,` Identifier AdditionalTemplateArguments+?
 
 LiteralType: Value
 
+# string & int & boolean
 UnionType: 
+  - IntersectionType 
+  - UnionType `|` IntersectionType
+
+IntersectionType:
   - TypeExpression
-  - TypeExpression Pipe UnionType?
+  - IntersectionType `&` TypeExpression
 
 Annotation: OpenBracket AnnotationStatement CloseBracket
 

--- a/adl/language/language.md
+++ b/adl/language/language.md
@@ -206,8 +206,9 @@ ResponseDeclaration: tba # still in discussion
 ResponseGroupDeclaration: tba # still in discussion
 
 ModelDeclaration: 
-  - Annotation+? `partial`? `model` Identifier TemplateDeclaration? AllOf? `;`
-  - Annotation+? `partial`? `model` Identifier TemplateDeclaration? AllOf? `{` PropertyDefinition+? `}`;
+  - Annotation+? `model` Identifier TemplateDeclaration? `;`
+  - Annotation+? `model` Identifier TemplateDeclaration? `{` PropertyDefinition+? `}`;
+  - Annotation+? `model` `=` Type
 
 TemplateDeclaration: `<` Identifier AdditionalTemplateDeclarations? `>`
 AdditionalTemplateDeclarations: `,` Identifier AdditionalTemplateDeclarations+?

--- a/adl/language/package.json
+++ b/adl/language/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/Azure/adl#readme",
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
   "devDependencies": {
-    "@types/mocha": "~7.0.2",
+    "@types/mocha": "^7.0.2",
     "@types/node": "14.0.27",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",

--- a/adl/language/parser.ts
+++ b/adl/language/parser.ts
@@ -218,7 +218,7 @@ export function parse(code: string) {
 
   function parseUnionExpression(): Expression {
     const pos = tokenPos();
-    let node: Expression = parseArrayExpression();
+    let node: Expression = parseIntersectionExpression();
 
     if (token() !== Kind.Bar) {
       return node;
@@ -230,6 +230,29 @@ export function parse(code: string) {
     }, pos);
 
     while (parseOptional(Kind.Bar)) {
+      const expr = parseArrayExpression();
+      node.options.push(expr);
+    }
+
+    node.end = tokenPos();
+
+    return node;
+  }
+
+  function parseIntersectionExpression(): Expression {
+    const pos = tokenPos();
+    let node: Expression = parseArrayExpression();
+
+    if (token() !== Kind.Ampersand) {
+      return node;
+    }
+
+    node = finishNode({
+      kind: SyntaxKind.IntersectionExpression,
+      options: [node]
+    }, pos);
+
+    while (parseOptional(Kind.Ampersand)) {
       const expr = parseArrayExpression();
       node.options.push(expr);
     }
@@ -513,6 +536,7 @@ export enum SyntaxKind {
   ModelExpression,
   ModelProperty,
   UnionExpression,
+  IntersectionExpression,
   TupleExpression,
   ArrayExpression,
   StringLiteral,
@@ -565,6 +589,7 @@ type Expression =
   | ModelExpressionNode
   | TupleExpressionNode
   | UnionExpressionNode
+  | IntersectionExpressionNode
   | IdentifierNode
   | StringLiteralNode
   | NumericLiteralNode;
@@ -640,6 +665,11 @@ export interface NumericLiteralNode extends Node {
 
 export interface UnionExpressionNode extends Node {
   kind: SyntaxKind.UnionExpression;
+  options: Array<Expression>;
+}
+
+export interface IntersectionExpressionNode extends Node {
+  kind: SyntaxKind.IntersectionExpression;
   options: Array<Expression>;
 }
 

--- a/adl/language/parser.ts
+++ b/adl/language/parser.ts
@@ -136,17 +136,34 @@ export function parse(code: string) {
     decorators: Array<DecoratorExpressionNode>
   ): ModelStatementNode {
     const pos = tokenPos();
+
     parseExpected(Kind.ModelKeyword);
     const id = parseIdentifier();
-    parseExpected(Kind.OpenBrace);
-    const properties = parseModelPropertyList();
 
-    return finishNode({
-      kind: SyntaxKind.ModelStatement,
-      id,
-      decorators,
-      properties
-    }, pos);
+    if (token() === Kind.OpenBrace) {
+      parseExpected(Kind.OpenBrace);
+      const properties = parseModelPropertyList();
+
+      return finishNode({
+        kind: SyntaxKind.ModelStatement,
+        id,
+        decorators,
+        properties
+      }, pos);
+    } else if (token() === Kind.Equals) {
+      parseExpected(Kind.Equals);
+      const assignment = parseExpression();
+      return finishNode({
+        kind: SyntaxKind.ModelStatement,
+        id,
+        assignment,
+        decorators,
+      }, pos);
+    } else {
+      throw error('Expected equals or open curly after model statement');
+    }
+
+
   }
 
   function parseModelPropertyList(): Array<ModelPropertyNode> {
@@ -583,7 +600,8 @@ export interface InterfaceParameterNode extends Node {
 export interface ModelStatementNode extends Node {
   kind: SyntaxKind.ModelStatement;
   id: IdentifierNode;
-  properties: Array<ModelPropertyNode>;
+  properties?: Array<ModelPropertyNode>;
+  assignment?: Expression;
   decorators: Array<DecoratorExpressionNode>;
 }
 

--- a/adl/language/scanner.ts
+++ b/adl/language/scanner.ts
@@ -384,7 +384,7 @@ export class Scanner {
               this.next(Kind.AmpersandAmpersand, 2) :
             this.#chNext === CharacterCodes.equals ?
               this.next(Kind.AmpersandEquals, 2) :
-              this.next(Kind.Exclamation);
+              this.next(Kind.Ampersand);
 
         case CharacterCodes.asterisk:
           return this.#chNext === CharacterCodes.asterisk ?

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { parse } from '../parser';
 
 describe('syntax', () => {
@@ -55,6 +54,13 @@ describe('syntax', () => {
        };`,
 
       'model Foo { "strKey": number, "😂😂😂": string }'
+    ]);
+  });
+
+  describe('model = statements', () => {
+    parseEach([
+      'model x = y',
+      'model foo = bar | baz'
     ]);
   });
 

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -88,6 +88,12 @@ describe('syntax', () => {
     ]);
   });
 
+  describe('intersection expressions', () => {
+    parseEach([
+      'model A { foo: B & C }'
+    ]);
+  });
+
   describe('interface statements', () => {
     parseEach([
       'interface Store {}',

--- a/adl/language/tsconfig.json
+++ b/adl/language/tsconfig.json
@@ -3,13 +3,9 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
-    "types": [
-      "node"
-    ]
+    "types": ["node", "mocha"]
   },
-  "include": [
-    "."
-  ],
+  "include": ["."],
   "exclude": [
     "dist",
     "test/scenarios/**",


### PR DESCRIPTION
This adds support for parsing two syntactic forms: model-assignment statements, and intersection type expressions.

`model Foo = <type>` can be used to alias models. It's nice to use this syntax because it makes an obvious place to attach decorators, implies very strongly that anything on the RHS must also be a model, and doesn't require an additional keyword.

Intersection syntax is like TypeScript. Precedence-wise it's higher than unions, so `a | b & c` -> `a | (b & c)`.

Model assignments combined with intersections gives interface extension patterns without requiring an additional `extends` keyword that  potentially brings in baggage around class inheritance semantics from other languages. It looks like:

```
model NotFoundResponse = Response & {
  statusCode: 404
}
```

The grammar is out of sync and needs to be updated especially around expressions. I tried to improve matters some, but more work is needed.