### PR TITLE
Parse template parameter definitions and applications

### DIFF
--- a/adl/language/compiler/binder.ts
+++ b/adl/language/compiler/binder.ts
@@ -1,10 +1,5 @@
-import {
-  InterfaceStatementNode,
-  ModelStatementNode,
-  Node,
-  SyntaxKind
-} from './parser';
 import { ADLSourceFile, Program } from './program';
+import { InterfaceStatementNode, ModelStatementNode, Node, SyntaxKind } from './types';
 
 // trying to avoid masking built-in Symbol
 export type Sym = DecoratorSymbol | TypeSymbol;

--- a/adl/language/compiler/checker.ts
+++ b/adl/language/compiler/checker.ts
@@ -1,27 +1,33 @@
-import {
-  ArrayExpressionNode,
-  IdentifierNode,
-  InterfaceParameterNode,
-  InterfaceStatementNode,
-  ModelExpressionNode,
-  ModelStatementNode,
-  Node,
-  NumericLiteralNode,
-  StringLiteralNode,
-  SyntaxKind,
-  TupleExpressionNode,
-  UnionExpressionNode
-} from './parser';
 import { ADLSourceFile, Program } from './program';
 import {
-  InterfaceType,
+  ArrayExpressionNode, IdentifierNode,
+
+
+  InterfaceParameterNode, InterfaceStatementNode, InterfaceType,
   InterfaceTypeParameter,
-  ModelType,
-  NumericLiteralType,
-  StringLiteralType,
-  TupleType,
+
+
+  ModelExpressionNode,
+  ModelStatementNode, ModelType,
+
+
+  Node,
+
+
+  NumericLiteralNode, NumericLiteralType,
+
+
+  StringLiteralNode, StringLiteralType,
+
+
+  SyntaxKind,
+
+
+  TupleExpressionNode, TupleType,
   Type,
-  UnionType
+
+
+  UnionExpressionNode, UnionType
 } from './types';
 
 export function createChecker(program: Program) {

--- a/adl/language/compiler/program.ts
+++ b/adl/language/compiler/program.ts
@@ -2,20 +2,18 @@ import { readdir, readFile } from 'fs/promises';
 import { join } from 'path';
 import { createBinder, Sym, SymbolTable } from './binder.js';
 import { createChecker } from './checker.js';
+import { parse } from './parser.js';
 import {
   ADLScriptNode,
   IdentifierNode,
   InterfaceStatementNode,
-  ModelStatementNode,
-  Node,
-  parse,
-  SyntaxKind
-} from './parser.js';
-import {
   InterfaceType,
+  ModelStatementNode,
   ModelType,
+  Node,
   NumericLiteralType,
   StringLiteralType,
+  SyntaxKind,
   Type
 } from './types.js';
 

--- a/adl/language/compiler/types.ts
+++ b/adl/language/compiler/types.ts
@@ -1,15 +1,6 @@
-import {
-  ArrayExpressionNode,
-  InterfaceParameterNode,
-  InterfacePropertyNode,
-  InterfaceStatementNode,
-  ModelPropertyNode,
-  Node,
-  NumericLiteralNode,
-  StringLiteralNode,
-  TupleExpressionNode
-} from './parser';
-
+/**
+ * Type System types
+ */
 export interface Type {
   node: Node;
 }
@@ -77,4 +68,174 @@ export interface TupleType extends Type {
 export interface UnionType extends Type {
   kind: 'Union';
   options: Array<Type>;
+}
+
+
+/**
+ * AST types
+ */
+export enum SyntaxKind {
+  ADLScript,
+  ImportStatement,
+  Identifier,
+  NamedImport,
+  DecoratorExpression,
+  MemberExpression,
+  InterfaceStatement,
+  InterfaceProperty,
+  InterfaceParameter,
+  ModelStatement,
+  ModelExpression,
+  ModelProperty,
+  UnionExpression,
+  IntersectionExpression,
+  TupleExpression,
+  ArrayExpression,
+  StringLiteral,
+  NumericLiteral,
+  AliasStatement,
+  TemplateApplication
+}
+
+export interface Node {
+  kind: SyntaxKind;
+  pos: number;
+  end: number;
+}
+
+export interface ADLScriptNode extends Node {
+  kind: SyntaxKind.ADLScript;
+  statements: Array<Statement>;
+}
+
+export type Statement =
+  | ImportStatementNode
+  | ModelStatementNode
+  | InterfaceStatementNode
+  | AliasStatementNode;
+
+export interface ImportStatementNode extends Node {
+  kind: SyntaxKind.ImportStatement;
+  id: IdentifierNode;
+  as: Array<NamedImportNode>;
+}
+
+export interface IdentifierNode extends Node {
+  kind: SyntaxKind.Identifier;
+  sv: string;
+}
+
+export interface NamedImportNode extends Node {
+  kind: SyntaxKind.NamedImport;
+  id: IdentifierNode;
+}
+
+export interface DecoratorExpressionNode extends Node {
+  kind: SyntaxKind.DecoratorExpression;
+  target: IdentifierNode | MemberExpressionNode;
+  arguments: Array<Expression>;
+}
+
+export type Expression =
+  | ArrayExpressionNode
+  | MemberExpressionNode
+  | ModelExpressionNode
+  | TupleExpressionNode
+  | UnionExpressionNode
+  | IntersectionExpressionNode
+  | TemplateApplicationNode
+  | IdentifierNode
+  | StringLiteralNode
+  | NumericLiteralNode;
+
+export interface MemberExpressionNode extends Node {
+  kind: SyntaxKind.MemberExpression;
+  id: IdentifierNode;
+  base: Expression | IdentifierNode;
+}
+
+export interface InterfaceStatementNode extends Node {
+  kind: SyntaxKind.InterfaceStatement;
+  id: IdentifierNode;
+  properties: Array<InterfacePropertyNode>;
+  decorators: Array<DecoratorExpressionNode>;
+}
+
+export interface InterfacePropertyNode extends Node {
+  kind: SyntaxKind.InterfaceProperty;
+  id: IdentifierNode;
+  parameters: Array<InterfaceParameterNode>;
+  returnType: Expression;
+  decorators: Array<DecoratorExpressionNode>;
+}
+
+export interface InterfaceParameterNode extends Node {
+  kind: SyntaxKind.InterfaceParameter;
+  id: IdentifierNode;
+  value: Expression;
+  optional: boolean;
+}
+
+export interface ModelStatementNode extends Node {
+  kind: SyntaxKind.ModelStatement;
+  id: IdentifierNode;
+  properties?: Array<ModelPropertyNode>;
+  assignment?: Expression;
+  templateParameters: Array<IdentifierNode>;
+  decorators: Array<DecoratorExpressionNode>;
+}
+
+export interface ModelExpressionNode extends Node {
+  kind: SyntaxKind.ModelExpression;
+  properties: Array<ModelPropertyNode>;
+  decorators: Array<DecoratorExpressionNode>;
+}
+
+export interface ArrayExpressionNode extends Node {
+  kind: SyntaxKind.ArrayExpression;
+  elementType: Expression;
+}
+export interface TupleExpressionNode extends Node {
+  kind: SyntaxKind.TupleExpression;
+  values: Array<Expression>;
+}
+
+export interface ModelPropertyNode extends Node {
+  kind: SyntaxKind.ModelProperty;
+  id: IdentifierNode | StringLiteralNode;
+  value: Expression;
+  decorators: Array<DecoratorExpressionNode>;
+  optional: boolean;
+}
+
+export interface StringLiteralNode extends Node {
+  kind: SyntaxKind.StringLiteral;
+  value: string;
+}
+
+export interface NumericLiteralNode extends Node {
+  kind: SyntaxKind.NumericLiteral;
+  value: string;
+}
+
+export interface UnionExpressionNode extends Node {
+  kind: SyntaxKind.UnionExpression;
+  options: Array<Expression>;
+}
+
+export interface IntersectionExpressionNode extends Node {
+  kind: SyntaxKind.IntersectionExpression;
+  options: Array<Expression>;
+}
+
+export interface AliasStatementNode extends Node {
+  kind: SyntaxKind.AliasStatement;
+  id: IdentifierNode;
+  target: Expression;
+}
+
+export interface TemplateApplicationNode extends Node {
+  kind: SyntaxKind.TemplateApplication;
+  target: Expression;
+  arguments: Array<Expression>;
 }

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -53,14 +53,17 @@ describe('syntax', () => {
          prop2: string
        };`,
 
-      'model Foo { "strKey": number, "😂😂😂": string }'
+      'model Foo { "strKey": number, "😂😂😂": string }',
+
+      'model Foo<A, B> { }'
     ]);
   });
 
   describe('model = statements', () => {
     parseEach([
       'model x = y',
-      'model foo = bar | baz'
+      'model foo = bar | baz',
+      'model bar<a, b> = a | b'
     ]);
   });
 
@@ -87,6 +90,13 @@ describe('syntax', () => {
       'model A { foo: B | C }'
     ]);
   });
+
+  describe('generic type instantiations', () => {
+    parseEach([
+      'model A = Foo<number, string>'
+    ]);
+  });
+
 
   describe('intersection expressions', () => {
     parseEach([

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -91,9 +91,10 @@ describe('syntax', () => {
     ]);
   });
 
-  describe('generic type instantiations', () => {
+  describe('template instantiations', () => {
     parseEach([
-      'model A = Foo<number, string>'
+      'model A = Foo<number, string>',
+      'model B = Foo<number, string>[]'
     ]);
   });
 

--- a/adl/language/test/test-scanner.ts
+++ b/adl/language/test/test-scanner.ts
@@ -3,7 +3,6 @@ import { readFile } from 'fs/promises';
 import { URL } from 'url';
 import { Kind, Position, Scanner } from '../compiler/scanner.js';
 
-
 type TokenEntry = [Kind, string?, 'error'?, Position?];
 
 function tokens(text: string): Array<TokenEntry> {


### PR DESCRIPTION
This parses template parameters. As usual the precedence matches TypeScript - it sits between array types and member expressions in precedence. The following are examples that parse now:

```
model A<X, Y> = X | Y;
model B<X, Y> { a: X, b: Y };
model C = A<1, 2>;
model D = A.B<3, 4>;
model E = A<5,6>[];
```

Because template instantiations have higher precedence than array expressions, `A[]<b>` is a syntax error.