### PR TITLE
Improve parsing of semicolons

### DIFF
--- a/adl/language/compiler/parser.ts
+++ b/adl/language/compiler/parser.ts
@@ -53,6 +53,14 @@ export function parse(code: string) {
             error('Cannot decorate an alias statement');
           }
           return parseAliasStatement();
+        case Kind.Semicolon:
+          if (decorators.length > 0) {
+            error('Cannot decorat an empty statement');
+          }
+          // no need to put empty statement nodes in the tree for now
+          // since we aren't trying to emit ADL
+          parseExpected(Kind.Semicolon);
+          continue;
       }
 
       throw error(`Expected statement, but found ${Kind[tok]}`);
@@ -161,6 +169,7 @@ export function parse(code: string) {
     } else if (token() === Kind.Equals) {
       parseExpected(Kind.Equals);
       const assignment = parseExpression();
+      parseExpected(Kind.Semicolon);
       return finishNode({
         kind: Types.SyntaxKind.ModelStatement,
         id,

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -135,6 +135,23 @@ describe('syntax', () => {
       'alias MyAlias : [ string, number ];'
     ]);
   });
+
+  describe('multiple statements', () => {
+    parseEach([`
+      model A { };
+      model B { }
+      model C = A;
+      ;
+      interface I {
+        foo(): number;
+      };
+      interface J {
+
+      }
+
+      
+    `]);
+  });
 });
 
 function parseEach(cases: Array<string>) {

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -61,9 +61,9 @@ describe('syntax', () => {
 
   describe('model = statements', () => {
     parseEach([
-      'model x = y',
-      'model foo = bar | baz',
-      'model bar<a, b> = a | b'
+      'model x = y;',
+      'model foo = bar | baz;',
+      'model bar<a, b> = a | b;'
     ]);
   });
 
@@ -93,8 +93,8 @@ describe('syntax', () => {
 
   describe('template instantiations', () => {
     parseEach([
-      'model A = Foo<number, string>',
-      'model B = Foo<number, string>[]'
+      'model A = Foo<number, string>;',
+      'model B = Foo<number, string>[];'
     ]);
   });
 
@@ -149,7 +149,7 @@ describe('syntax', () => {
 
       }
 
-      
+
     `]);
   });
 });


### PR DESCRIPTION
Previously, the required semicolon after model-assignment statements was not being parsed. Additionally, while semi-colons aren't required after brace-bound statements, we will now parse them. These empty statements are ignored for now, but if we ever need to emit ADL (e.g. for `adl fmt`, something I hope we'll have!) we'll want to create nodes for these.