### PR TITLE
parse interface params, fix bug w/ multiple decorators on members

### DIFF
--- a/adl/language/compiler/parser.ts
+++ b/adl/language/compiler/parser.ts
@@ -74,6 +74,11 @@ export function parse(code: string) {
     const pos = tokenPos();
     parseExpected(Kind.InterfaceKeyword);
     const id = parseIdentifier();
+    let parameters: Array<Types.InterfaceParameterNode> = [];
+
+    if (token() === Kind.OpenParen) {
+      parameters = parseParameterList();
+    }
     parseExpected(Kind.OpenBrace);
     const properties: Array<Types.InterfacePropertyNode> = [];
 
@@ -83,7 +88,8 @@ export function parse(code: string) {
       if (token() == Kind.CloseBrace) {
         break;
       }
-      if (token() === Kind.At || token() === Kind.OpenBracket) {
+
+      while (token() === Kind.At || token() === Kind.OpenBracket) {
         memberDecorators.push(parseDecoratorExpression());
       }
       properties.push(parseInterfaceProperty(memberDecorators));
@@ -96,6 +102,7 @@ export function parse(code: string) {
       kind: Types.SyntaxKind.InterfaceStatement,
       decorators,
       id,
+      parameters,
       properties
     }, pos);
   }
@@ -199,7 +206,7 @@ export function parse(code: string) {
       if (token() == Kind.CloseBrace) {
         break;
       }
-      if (token() === Kind.At || token() === Kind.OpenBracket) {
+      while (token() === Kind.At || token() === Kind.OpenBracket) {
         memberDecorators.push(parseDecoratorExpression());
       }
       properties.push(parseModelProperty(memberDecorators));

--- a/adl/language/compiler/types.ts
+++ b/adl/language/compiler/types.ts
@@ -157,6 +157,7 @@ export interface MemberExpressionNode extends Node {
 export interface InterfaceStatementNode extends Node {
   kind: SyntaxKind.InterfaceStatement;
   id: IdentifierNode;
+  parameters: Array<InterfaceParameterNode>;
   properties: Array<InterfacePropertyNode>;
   decorators: Array<DecoratorExpressionNode>;
 }

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -55,7 +55,9 @@ describe('syntax', () => {
 
       'model Foo { "strKey": number, "😂😂😂": string }',
 
-      'model Foo<A, B> { }'
+      'model Foo<A, B> { }',
+
+      'model Car { @foo @bar x: number }'
     ]);
   });
 
@@ -124,7 +126,9 @@ describe('syntax', () => {
       'interface Store { read(): int32 }',
       'interface Store { read(): int32, write(v: int32): {} }',
       'interface Store { read(): int32; write(v: int32): {} }',
-      '@foo interface Store { @dec read():number, @dec write(n: number): {} }'
+      '@foo interface Store { @dec read():number, @dec write(n: number): {} }',
+      '@foo @bar interface Store { @foo @bar read(): number; }',
+      'interface Store(apiKey: string, otherArg: number) { }'
     ]);
   });
 


### PR DESCRIPTION
This parses interfaces with the proposed arguments list that is used for arguments common among all the interface members (think authentication tokens, common headers, service endpoints, etc.)

There was also a bug with parsing decorators for members where only one was allowed. This has been fixed.