### PR TITLE
Skip comments in parser

### DIFF
--- a/adl/language/compiler/parser.ts
+++ b/adl/language/compiler/parser.ts
@@ -535,9 +535,21 @@ export function parse(code: string) {
   function nextToken() {
     scaner.scan();
 
-    // skip whitespace tokens for now
-    while (token() === Kind.Whitespace || token() === Kind.NewLine) {
+    // skip whitespace and comment tokens for now
+    while (isTrivia(token())) {
       scaner.scan();
+    }
+  }
+
+  function isTrivia(token: Kind) {
+    switch (token) {
+      case Kind.Whitespace:
+      case Kind.NewLine:
+      case Kind.MultiLineComment:
+      case Kind.SingleLineComment:
+        return true;
+      default:
+        return false;
     }
   }
 

--- a/adl/language/compiler/scanner.ts
+++ b/adl/language/compiler/scanner.ts
@@ -393,7 +393,7 @@ export class Scanner {
               this.next(Kind.AsteriskAsterisk, 2) :
             this.#chNext === CharacterCodes.equals ?
               this.next(Kind.AsteriskEquals, 2) :
-              this.next(Kind.AsteriskEquals);
+              this.next(Kind.Asterisk);
 
         case CharacterCodes.plus:
           return this.#chNext === CharacterCodes.plus ?
@@ -420,7 +420,7 @@ export class Scanner {
           return this.#chNext === CharacterCodes.slash ?
             this.scanSingleLineComment() :
             this.#chNext === CharacterCodes.asterisk ?
-              this.scanMulitLineComment() :
+              this.scanMultiLineComment() :
 
               this.#chNext === CharacterCodes.equals ?
                 this.next(Kind.SlashEquals) :
@@ -620,7 +620,7 @@ export class Scanner {
     return this.#ch === CharacterCodes.tab ? (this.#column % this.tabWidth || this.tabWidth) : 1;
   }
 
-  private scanUntil(predicate: (char: number, charNext: number, charNextNext: number) => boolean, expectedClose?: string) {
+  private scanUntil(predicate: (char: number, charNext: number, charNextNext: number) => boolean, expectedClose?: string, consumeClose?: number) {
     const start = this.#offset;
 
     do {
@@ -644,6 +644,10 @@ export class Scanner {
 
     } while (!predicate(this.#ch, this.#chNext, this.#chNextNext));
 
+    if (consumeClose) {
+      this.advance(consumeClose);
+    }
+
     // and after...
     this.markPosition();
 
@@ -655,9 +659,9 @@ export class Scanner {
     return this.token = Kind.SingleLineComment;
   }
 
-  private scanMulitLineComment() {
-    this.value = this.scanUntil((ch, chNext) => ch === CharacterCodes.asterisk && chNext === CharacterCodes.slash, '*/');
-    return Kind.MultiLineComment;
+  private scanMultiLineComment() {
+    this.value = this.scanUntil((ch, chNext) => ch === CharacterCodes.asterisk && chNext === CharacterCodes.slash, '*/', 2);
+    return this.token = Kind.MultiLineComment;
   }
 
   private scanString() {

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -1,4 +1,5 @@
 import { parse } from '../compiler/parser.js';
+import { SyntaxKind } from '../compiler/types.js';
 
 describe('syntax', () => {
   describe('import statements', () => {
@@ -156,6 +157,20 @@ describe('syntax', () => {
 
     `]);
   });
+
+  describe('comments', () => {
+    parseEach([`
+      // Comment
+      model A { /* Another comment */
+        /*
+          and
+          another
+        */
+        property /* 👀 */ : /* 👍 */ int32; // one more
+      }
+      `]);
+  });
+
 });
 
 function parseEach(cases: Array<string>) {
@@ -167,7 +182,10 @@ function parseEach(cases: Array<string>) {
 }
 
 function dumpAST(astNode: any) {
-  console.log(JSON.stringify(astNode, null, 4));
+  const replacer = function(this: any, key: string, value: any) {
+    return key == 'kind' ? SyntaxKind[value] : value;
+  };
+  console.log(JSON.stringify(astNode, replacer, 4));
 }
 
 function shorten(code: string) {


### PR DESCRIPTION
Working next on more sophistication to actually retrieve the comments and so forth, but this is a small precursor to at least unblock the use of comments by simply skipping them in the parser.

Also made dumpAST in tests convert numeric SyntaxKind to string so that it is easier to eyeball.