### PR TITLE
Remove doc decorator sugar and shorten `@description` to `@doc`

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
     {
       "label": "build/watch",
       "type": "shell",
-      "command": "tsc --build --watch",
+      "command": "node ${workspaceFolder}/adl/core/node_modules/typescript/lib/tsc.js --build --watch",
       "isBackground": true,
       "problemMatcher": "$tsc-watch",
       "group": {

--- a/adl/core/model/api-model.ts
+++ b/adl/core/model/api-model.ts
@@ -136,11 +136,14 @@ export function isModelInterface(declaration: InterfaceDeclaration) {
 
 export class Files {
   readonly api: ApiModel;
-  readonly files!: Array<ExtendedSourceFile>;
+  #files!: Array<ExtendedSourceFile>;
+  public get files(): Array<ExtendedSourceFile> {
+    return this.#files;
+  }
 
   protected constructor(api?: ApiModel, sourceFiles?: Array<ExtendedSourceFile>) {
     if (api) {
-      this.files = sourceFiles || api.files;
+      this.#files = sourceFiles || api.files;
     }
     this.api = api || (this instanceof ApiModel ? this : fail('requires api model in constructor'));
 

--- a/adl/language/compiler/scanner.ts
+++ b/adl/language/compiler/scanner.ts
@@ -49,10 +49,7 @@ export enum Kind {
 
   // Literals
   NumericLiteral,
-  BigIntLiteral,
   StringLiteral,
-  TripleQuotedStringLiteral,
-  RegularExpressionLiteral,
 
   // Punctuation
   OpenBrace,
@@ -731,7 +728,7 @@ export class Scanner {
 
     this.value = text;
     this.stringValue = value;
-    return this.token = tripleQuoted ? Kind.TripleQuotedStringLiteral : Kind.StringLiteral;
+    return this.token = Kind.StringLiteral;
   }
 
   private unindentTripleQuoteString(text: string) {

--- a/adl/language/lib/decorators.ts
+++ b/adl/language/lib/decorators.ts
@@ -1,14 +1,14 @@
 import { Program } from "../compiler/program";
 import { Type } from "../compiler/types";
 
-const desc = new Map<Type, string>();
+const docs = new Map<Type, string>();
 
-export function description(program: Program, target: Type, text: string) {
-  desc.set(target, text);
+export function doc(program: Program, target: Type, text: string) {
+  docs.set(target, text);
 }
 
-export function getDescription(target: Type) {
-  return desc.get(target);
+export function getDoc(target: Type) {
+  return docs.get(target);
 }
 
 export function inspectType(program: Program, target: Type, text: string) {

--- a/adl/language/lib/openapi.ts
+++ b/adl/language/lib/openapi.ts
@@ -1,6 +1,6 @@
 import { Program } from '../compiler/program.js';
 import { ArrayType, InterfaceType, InterfaceTypeProperty as InterfacePropertyType, ModelType, ModelTypeProperty as ModelPropertyType, Type, UnionType } from '../compiler/types.js';
-import { getDescription } from './decorators.js';
+import { getDoc } from './decorators.js';
 import {
   basePathForResource,
   getHeaderFieldName,
@@ -164,7 +164,7 @@ function createOAPIEmitter(program: Program) {
     if (operationIds.has(prop)) {
       currentEndpoint.operationId = operationIds.get(prop);
     }
-    currentEndpoint.summary = getDescription(prop);
+    currentEndpoint.summary = getDoc(prop);
     currentEndpoint.consumes = [];
     currentEndpoint.produces = [];
     currentEndpoint.parameters = [];
@@ -206,7 +206,7 @@ function createOAPIEmitter(program: Program) {
       schema: getSchemaPlaceholder(responseModel),
     };
 
-    const desc = getDescription(responseModel);
+    const desc = getDoc(responseModel);
     if (desc) {
       response.description = desc;
     }
@@ -215,7 +215,7 @@ function createOAPIEmitter(program: Program) {
       for (const [name, prop] of responseModel.properties) {
         const statusInfo = isStatus(prop);
         const headerInfo = getHeaderFieldName(prop);
-        const desc = getDescription(prop);
+        const desc = getDoc(prop);
         const type = prop.type;
 
         if (statusInfo && type.kind === "Number") {
@@ -312,7 +312,7 @@ function createOAPIEmitter(program: Program) {
     ph.in = kind;
     ph.requred = !param.optional;
     ph.schema = getSchemaPlaceholder(param.type);
-    ph.description = getDescription(param);
+    ph.description = getDoc(param);
 
     if (kind === 'body') {
       let contentType = 'application/json';
@@ -394,7 +394,7 @@ function createOAPIEmitter(program: Program) {
       type: 'object',
       required: [],
       properties: {},
-      description: getDescription(model),
+      description: getDoc(model),
     };
 
     for (const [name, prop] of model.properties) {
@@ -402,7 +402,7 @@ function createOAPIEmitter(program: Program) {
       const queryInfo = getQueryParamName(prop);
       const pathInfo = getPathParamName(prop);
       const statusInfo = isStatus(prop);
-      const description = getDescription(prop);
+      const description = getDoc(prop);
       if (headerInfo || queryInfo || pathInfo || statusInfo) {
         continue;
       } else {

--- a/adl/language/samples/appconfig/keys.adl
+++ b/adl/language/samples/appconfig/keys.adl
@@ -4,7 +4,7 @@ interface KeysResource(
   ... SyncTokenHeader
 ) {
 
-  @description("Gets a list of keys.")
+  @doc("Gets a list of keys.")
   @operationId("GetKeys")
   list(
     ... AcceptDatetimeHeader,
@@ -13,7 +13,7 @@ interface KeysResource(
     @header after: string,
   ): Ok<SyncTokenHeader & KeyPage> | Error,
 
-  @description("Requests the headers and status of the given resource.")
+  @doc("Requests the headers and status of the given resource.")
   @operationId("CheckKeys")
   listHead(
     ... AcceptDatetimeHeader,

--- a/adl/language/samples/appconfig/keyvalues.adl
+++ b/adl/language/samples/appconfig/keyvalues.adl
@@ -1,18 +1,18 @@
-@description("Used for /kv endpoints (key in query)")
+@doc("Used for /kv endpoints (key in query)")
 model KeyFilters {
-  @description("A filter for the name of the returned keys.")
+  @doc("A filter for the name of the returned keys.")
   @query key?: string;
 
-  @description("A filter used to match labels")
+  @doc("A filter used to match labels")
   @query label?: string;
 }
 
-@description("Used for /kv/{id} endpoints (key in path)")
+@doc("Used for /kv/{id} endpoints (key in path)")
 model KeyWithFilters {
-  @description("A filter for the name of the returned keys.")
+  @doc("A filter for the name of the returned keys.")
   @path key: string;
 
-  @description("A filter used to match labels")
+  @doc("A filter used to match labels")
   @query label?: string;
 }
 
@@ -22,48 +22,48 @@ interface KeyValuesResource(
   ... SyncTokenHeader
 ) {
 
-  @description("Gets a list of key-values.")
+  @doc("Gets a list of key-values.")
   @operationId("GetKeyValues")
   list(
     ... AcceptDatetimeHeader,
     ... KeyFilters,
     
-    @description("Instructs the server to return elements that appear after the element referred to by the specified token.")
+    @doc("Instructs the server to return elements that appear after the element referred to by the specified token.")
     @query After: date,
 
-    @description("Used to select what fields are present in the returned resource(s).")
+    @doc("Used to select what fields are present in the returned resource(s).")
     @query $Select?: KeyField[],
 
   ): Ok<SyncTokenHeader & Page<KeyValue>> | Error;
 
-  @description("Gets a list of key-values.")
+  @doc("Gets a list of key-values.")
   @operationId("CheckKeyValues")
   listHead(
     ... AcceptDatetimeHeader,
     ... KeyFilters,
 
-    @description("Instructs the server to return elements that appear after the element referred to by the specified token.")
+    @doc("Instructs the server to return elements that appear after the element referred to by the specified token.")
     @query After: date,
 
-    @description("Used to select what fields are present in the returned resource(s).")
+    @doc("Used to select what fields are present in the returned resource(s).")
     @query $Select?: KeyField[]
 
   ): Ok<SyncTokenHeader> | Error;
 
 
-  @description("Gets a single key-value.")
+  @doc("Gets a single key-value.")
   @operationId("GetKeyValue")
   read(
     ... ETagHeaders,
     ... AcceptDatetimeHeader,
     ... KeyWithFilters,
 
-    @description("Used to select what fields are present in the returned resource(s).")
+    @doc("Used to select what fields are present in the returned resource(s).")
     @query $Select?: KeyField[]
 
   ): Ok<KeyValueHeaders & KeyValue> | Error;
 
-  @description("Requests the headers and status of the given resource.")
+  @doc("Requests the headers and status of the given resource.")
   @operationId("CheckKeyValue")
   readHead(
     ... ETagHeaders,
@@ -71,7 +71,7 @@ interface KeyValuesResource(
     ... KeyWithFilters
   ): Ok<SyncTokenHeader & LastModifiedHeader> | Error;
 
-  @description("Creates a key-value.")
+  @doc("Creates a key-value.")
   @operationId("PutKeyValue")
   createOrUpdate(
     ... ETagHeaders,
@@ -81,7 +81,7 @@ interface KeyValuesResource(
     @body entity: KeyValue,
   ): Ok<KeyValueHeaders & KeyValue> | Error;
 
-  @description("Updates a key-value pair")
+  @doc("Updates a key-value pair")
   createOrUpdate(
     ... ETagHeaders,
     ... KeyWithFilters,
@@ -91,7 +91,7 @@ interface KeyValuesResource(
   ): Ok<KeyValueHeaders & KeyValue> | Error;
 
 
-  @description("Deletes a key-value.")
+  @doc("Deletes a key-value.")
   @operationId("DeleteKeyValue")
   delete(
     ... KeyWithFilters,

--- a/adl/language/samples/appconfig/labels.adl
+++ b/adl/language/samples/appconfig/labels.adl
@@ -5,7 +5,7 @@ interface LabelsResource(
   ... SyncTokenHeader
 ) {
 
-  @description("Gets a list of labels.")
+  @doc("Gets a list of labels.")
   @operationId("GetLabels")
   list(
     ... AcceptDatetimeHeader,
@@ -14,7 +14,7 @@ interface LabelsResource(
     @query after?: string,
   ): Ok<SyncTokenHeader & LabelPage> | Error;
 
-  @description("Requests the headers and status of the given resource.")
+  @doc("Requests the headers and status of the given resource.")
   @operationId("CheckLabels")
   listHead(
     ... AcceptDatetimeHeader,

--- a/adl/language/samples/appconfig/models.adl
+++ b/adl/language/samples/appconfig/models.adl
@@ -21,9 +21,7 @@ model Ok<T> {
 }
 
 model SyncTokenHeader {
-  """
-  Used to guarantee real-time consistency between requests.
-  """
+  @doc "Used to guarantee real-time consistency between requests."
   @header syncToken?: string;
 }
 
@@ -31,15 +29,22 @@ model ServiceParams {
   @query apiVersion: string;
 }
 
-"""
-Azure App Configuration error object.
-"""
+@doc "Azure App Configuration error object."
 model Error {
-  type: string            "The type of the error";
-  title: string           "A brief summary of the error.";
-  name: string            "The name of the parameter that resulted in the error.";
-  detail: string          "A detailed description of the error.";
-  statusCode: int32        "The HTTP status code that the error maps to.";
+  @doc "The type of the error"
+  type: string;
+
+  @doc "A brief summary of the error."
+  title: string;
+
+  @doc "The name of the parameter that resulted in the error."
+  name: string;
+
+  @doc "A detailed description of the error."
+  detail: string;
+
+  @doc "The HTTP status code that the error maps to." 
+  statusCode: int32;
 }
 
 model Page<T> {

--- a/adl/language/samples/appconfig/revisions.adl
+++ b/adl/language/samples/appconfig/revisions.adl
@@ -5,19 +5,23 @@ interface RevisionsResource(
   ... SyncTokenHeader
 ) {
 
-  "Gets a list of revisions."
-  @operationId("GetRevisions")
+  @doc "Gets a list of revisions."
+  @operationId "GetRevisions"
   list(
     ... AcceptDatetimeHeader,
 
+    @doc "Used to select what fields are present in the returned resource(s)."
+    @query $Select?: KeyField[],
 
-    @query $Select?: KeyField[]   "Used to select what fields are present in the returned resource(s).",
-    @query label: string          "A filter used to match labels",
-    @query key: string            "A filter used to match keys.",
+    @doc "A filter used to match labels"
+    @query label: string,
+
+    @doc "A filter used to match keys."
+    @query key: string,
   ): Ok<SyncTokenHeader & Page<KeyValue>> | Error;
 
-  "Requests the headers and status of the given resource."
-  @operationId("CheckRevisions")
+  @doc "Requests the headers and status of the given resource."
+  @operationId "CheckRevisions"
   listHead(
     ... AcceptDatetimeHeader,
 

--- a/adl/language/samples/petstore/decorators.js
+++ b/adl/language/samples/petstore/decorators.js
@@ -1,12 +1,12 @@
 // pretend I just typed this file from scratch... and saved it
-import { description } from "../../dist/lib/decorators.js";
+import { doc } from "../../dist/lib/decorators.js";
 
-export function fancyDescription(program, target, text) {
+export function fancyDoc(program, target, text) {
   text = `<blink>${text}</blink>`;
-  description(program, target, text);
+  doc(program, target, text);
 }
 
-export function evenFancierDescription(program, target, ...args) {
+export function evenFancierDoc(program, target, ...args) {
   args[0] = `<marquee><blink>${args[0]}</blink></marquee>`;
-  description(program, target, ...args);
+  doc(program, target, ...args);
 }

--- a/adl/language/samples/petstore/petstore.adl
+++ b/adl/language/samples/petstore/petstore.adl
@@ -33,26 +33,22 @@ model PetId {
   @path petId: int32;
 }
 
-"""
-Manage your pets
-"""
-@resource("/pets")
+@doc "Manage your pets."
+@resource "/pets"
 interface PetsResource {
-  """
-  Delete a pet.
-  """
+  @doc "Delete a pet."
   delete(... PetId): Ok<{}> | Error;
 
-  @fancyDescription("list pets")
+  @fancyDoc "List pets."
   list(@query nextLink?: string): Ok<Page<Pet>> | Error;
 
-  @description("Returns a pet. Supports eTags.")
+  @doc "Returns a pet. Supports eTags."
   read(... PetId): Ok<Pet> | NotModified<Pet> | Error;
 
   create(@body pet: Pet): Ok<Pet> | Error;
 }
 
-@resource("/pets/{petId}/toys")
+@resource "/pets/{petId}/toys"
 interface ListPetToysResponse {
   list(@path petId: string, @query nameFilter: string): Ok<Page<Toy>> | Error;
 }

--- a/adl/language/test/test-parser.ts
+++ b/adl/language/test/test-parser.ts
@@ -61,6 +61,17 @@ describe('syntax', () => {
          prop2: string
        };`,
 
+      `@doc """
+       Documentation
+       """
+       model Car {
+         @doc "first"
+         prop1: number;
+
+         @doc "second"
+         prop2: number;
+       }`,
+
       'model Foo { "strKey": number, "😂😂😂": string }',
 
       'model Foo<A, B> { }',
@@ -179,73 +190,6 @@ describe('syntax', () => {
         property /* 👀 */ : /* 👍 */ int32; // one more
       }
       `]);
-  });
-
-  describe('description decorator sugar', () => {
-    parseEach([
-      `
-      """
-      Long description
-      On two lines
-      """
-      @dec()
-      model Model {
-        @dec property1: Type    "short description";
-        property2: Type         'something "else"'
-      }`,
-      `
-      'short description'
-      model Model {
-        '''
-        Long description
-        On two lines
-        '''
-        property: int32 \`short description\`;
-      }`,
-      `
-      "short description"
-      interface I {
-          doSomething(): Type     "short description";
-          doSomethingElse(): Type \`something "else"\`;
-      }`,
-      `
-      \`\`\`
-      Long description
-      On two lines
-      \`\`\`
-      @dec()
-      interface I {
-        """
-        Another long description
-        
-        **NOTE** Markdown goes here
-        """
-        doSomething(): Type;
-      }`,
-      `
-       """
-       A point in two dimensional space
-       """
-       @fun true
-       @profit false
-       @example
-       '''
-       {
-         "x": 42,
-         "y": 42,
-       }
-       '''
-       model Point {
-         @description "x coordinate"
-         @fieldNum 1
-         x: int32;
-
-         @description "y coordinate"
-         @fieldNum 2
-         y: int32;
-       }
-       `
-    ]);
   });
 });
 

--- a/adl/language/test/test-scanner.ts
+++ b/adl/language/test/test-scanner.ts
@@ -121,11 +121,11 @@ describe('scanner', () => {
     strictEqual(scanner.rescanGreaterThan(), Kind.GreaterThanGreaterThan);
   });
 
-  function scanString(text: string, expectedValue: string, expectedToken: Kind) {
+  function scanString(text: string, expectedValue: string) {
     const scanner = new Scanner(text);
     scanner.onError = (msg, params) => { throw new Error(format(msg.text, ...params)); };
-    strictEqual(scanner.scan(), expectedToken);
-    strictEqual(scanner.token, expectedToken);
+    strictEqual(scanner.scan(), Kind.StringLiteral);
+    strictEqual(scanner.token, Kind.StringLiteral);
     strictEqual(scanner.value, text);
     strictEqual(scanner.stringValue, expectedValue);
   }
@@ -133,15 +133,13 @@ describe('scanner', () => {
   it('scans strings single-line strings with escape sequences', () => {
     scanString(
       '"Hello world \\r\\n \\t \\\' \\" \\` \\\\ !"',
-      'Hello world \r\n \t \' " ` \\ !',
-      Kind.StringLiteral);
+      'Hello world \r\n \t \' " ` \\ !');
   });
 
   it('scans multi-line strings', () => {
     scanString(
       '`More\r\nthan\r\none\r\nline`',
-      'More\nthan\none\nline',
-      Kind.StringLiteral);
+      'More\nthan\none\nline');
   });
 
   it('scans triple-quoted strings', () => {
@@ -155,8 +153,7 @@ describe('scanner', () => {
       """`,
       // NOTE: sloppy blank line formatting and trailing whitespace after open
       //       quotes above is deliberately tolerated.
-      'This is a triple-quoted string\n\n\n\nAnd this is another line',
-      Kind.TripleQuotedStringLiteral);
+      'This is a triple-quoted string\n\n\n\nAnd this is another line');
   });
 
   it('parses this file', async () => {


### PR DESCRIPTION
Fixes #202 

Unadorned string literal can no longer be used as description decorator, but `@description` is shortened to `@doc`. There are also no more decorations possible trailing member declarations.

The first commit is  totally separate. I started getting an error in VS Code about code outside my change, around overriding a non-getter with a getter. This appeared to be caused by the default build/watch task using the global tsc which was v4.0.x on my machine vs v3.9.x that is in package.json and used by CLI and CI builds. I went ahead and fixed the error in the code, and I also changed the build/watch task to use the project's tsc version.