### PR TITLE
Hack until OpenAPI 2 is valid for petstore and appconfig

### DIFF
--- a/adl/language/compiler/checker.ts
+++ b/adl/language/compiler/checker.ts
@@ -130,6 +130,10 @@ export function createChecker(program: Program) {
         return (<UnionType>type).options.map(getTypeName).join(' | ');
       case 'Array':
         return getTypeName((<ArrayType>type).elementType) + '[]';
+      case 'String':
+      case 'Number':
+      case 'Boolean':
+        return type.value.toString();
     }
 
     return '(unnamed type)';


### PR DESCRIPTION
I mentioned last week in passing that I had seen some issues in the OpenAPI 2 emit, but didn't have a list, and it wasn't clear if all of them were known or not.

I set out to put together the list here. I've also fixed them all in a hurry in this PR as that ended up being the best way to enumerate them. However, some of the fixes are opportunistic and inefficient, and should probably be done better.

My methodology here was:

* generate petstore and appconfig
* paste output into https://editor.swagger.io/
* fix issues it flags
* repeat until all issues are gone

And these are all of the issues that I found this way:

1. Typo: s/requred/required/
2. title and version are required
3. response description is required
4. path parameter not emitted
5. some parameters duplicated
6. non-body parameters have to inline their schema, don't have schema property, can't ref schema. Also can only be of certain types, but I didn't validate that here.
7. Typo: s/Array/array
8. `required` array must have at least one element (or not be defined)
9. constants should be enum of one element
10. oneOf is not valid in OpenAPI v2 (fix: use enum for literals of same type, error otherwise.)
11. Typo: #/parameters instead of #/definitions to ref schemas
12. names of parameters and schemas with symbols like `[`  and `<` caused invalid $refs that would have to be URL encoded. (URL encoding was ugly and for some reason caused the swagger editor to still have resolution problems, so I converted the names with some hacky search and replace and counter bumping instead.)
13. parameters with same names but different defintions (type or location) were getting shared
14. some primitives returned wrong type

You can see the output delta before this PR and after it here: 

https://github.com/nguerrera/adl-oai2-diff/commit/8a7d19b21c88d1eae616f7faf9a9ae42c912f144

Side notes:
* I wanted to use `@azure-tools/openapi` to get typing to help me fix some of these, but I gave up fighting to get the module to resolve after a little while. We should push on this, though. I also found a couple of bugs in @azure-tools/openapi and I will send a PR to fix those.
* It would also be good to have an automated test that runs a swagger validator.