### PR TITLE
Emit better names to OpenAPI

### DIFF
--- a/adl/language/compiler/types.ts
+++ b/adl/language/compiler/types.ts
@@ -26,9 +26,10 @@ export interface ModelType extends BaseType {
   kind: 'Model';
   name: string;
   properties: Map<string, ModelTypeProperty>;
+  ownProperties: Map<string, ModelTypeProperty>;
+  baseModels: Array<ModelType>;
   templateArguments?: Array<Type>;
   templateNode?: Node;
-  intersectionMembers?: Array<Type>;
   assignmentType?: Type;
 }
 

--- a/adl/language/lib/rest.ts
+++ b/adl/language/lib/rest.ts
@@ -65,11 +65,3 @@ export function isBody(entity: Type) {
   return bodyFields.has(entity);
 }
 
-const statusFields = new Set<Type>();
-export function status(program: Program, entity: Type) {
-  statusFields.add(entity);
-}
-
-export function isStatus(entity: Type) {
-  return statusFields.has(entity);
-}

--- a/adl/language/samples/appconfig/keyvalues.adl
+++ b/adl/language/samples/appconfig/keyvalues.adl
@@ -82,6 +82,7 @@ interface KeyValuesResource(
   ): Ok<KeyValueHeaders & KeyValue> | Error;
 
   @doc("Updates a key-value pair")
+  @operationId("UpdateKeyValue")
   createOrUpdate(
     ... ETagHeaders,
     ... KeyWithFilters,

--- a/adl/language/samples/appconfig/locks.adl
+++ b/adl/language/samples/appconfig/locks.adl
@@ -3,12 +3,14 @@ interface LocksResource(
   ... ServiceParams,
   ... SyncTokenHeader
 ) {
+  @operationId("GetLock")
   read(
     @path key: string,
     @query label: string,
     ... ETagHeaders,
   ): Ok<SyncTokenHeader & KeyValue> | Error;
 
+  @operationId("DeleteLock")
   delete(
     @path key: string,
     @query label: string,

--- a/adl/language/samples/appconfig/models.adl
+++ b/adl/language/samples/appconfig/models.adl
@@ -15,6 +15,7 @@ model AcceptDatetimeHeader {
   @header acceptDatetime: date;
 }
 
+@doc "Success"
 model Ok<T> {
   @header statusCode: 200;
   ... T;

--- a/adl/language/samples/petstore/petstore.adl
+++ b/adl/language/samples/petstore/petstore.adl
@@ -1,3 +1,4 @@
+@doc "Success"
 model Ok<T> {
   @header statusCode: 200;
   ... T;
@@ -8,6 +9,7 @@ model Pet {
   tag?: string;
 }
 
+@doc "Error"
 model Error {
   code: int32;
   message: string;
@@ -19,6 +21,7 @@ model Toy {
   name: string;
 }
 
+@doc "Not modified"
 model NotModified<T> {
   @header statusCode: 304;
   ... T;


### PR DESCRIPTION
See https://github.com/nguerrera/adl-oai2-diff/commit/df2e52240028ad01b3927027fce11c0e17443649 for the appconfig/petstore emit diff. I haven't tried autorest yet, but to my naked eye the swagger is looking a lot closer to something I might have written by hand.

1. Model `A & B` and `{ ...A, ...B }` as having "base models" A and B. These are now semantic sugar for the same type.

2. When emitting schema, if possible, reduce models down to single base model that has actual schema properties where possible. For example, in `OK<T>`, once you put the statusCode elsewhere you're left with T so use that.

3. Emit "base models" using OpenAPI allOf.

4. Instead of name munging, any type with an unspeakable name in OpenAPI simply gets inlined. Users can make type aliases with good names to avoid this inlining if desired.

5. Inline parameters that are inlined in ADL. To end up in `#/parameters`, a parameter has to be shared via spreading in ADL. This allows us to pick a good name for the `#/paramters` map: if the spread type has only one property, use the type name, otherwise use `(type name).(property name)`. It also gives the OpenAPI output a structure that mirrors the ADL.

6. Fix issues with responses. We were not emitting status codes other than 200, and not emitting response headers.