### PR TITLE
Add basic ADL command line interface

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2,12 +2,14 @@ dependencies:
   '@rush-temp/adl.language': 'file:projects/adl.language.tgz'
   '@types/mocha': 7.0.2
   '@types/node': 14.0.27
+  '@types/yargs': 15.0.12
   '@typescript-eslint/eslint-plugin': 2.28.0_d62df2f848be5291fc9d2809dd11a3fb
   '@typescript-eslint/parser': 2.28.0_eslint@6.8.0+typescript@3.9.7
   eslint: 6.8.0
   mocha: 7.1.2
   ts-node: 8.10.2_typescript@3.9.7
   typescript: 3.9.7
+  yargs: 16.2.0
 lockfileVersion: 5.1
 packages:
   /@babel/code-frame/7.12.11:
@@ -44,6 +46,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
+  /@types/yargs-parser/20.2.0:
+    dev: false
+    resolution:
+      integrity: sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==
+  /@types/yargs/15.0.12:
+    dependencies:
+      '@types/yargs-parser': 20.2.0
+    dev: false
+    resolution:
+      integrity: sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==
   /@typescript-eslint/eslint-plugin/2.28.0_d62df2f848be5291fc9d2809dd11a3fb:
     dependencies:
       '@typescript-eslint/experimental-utils': 2.28.0_eslint@6.8.0+typescript@3.9.7
@@ -330,6 +342,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  /cliui/7.0.4:
+    dependencies:
+      string-width: 4.2.0
+      strip-ansi: 6.0.0
+      wrap-ansi: 7.0.0
+    dev: false
+    resolution:
+      integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
   /color-convert/1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -463,6 +483,12 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  /escalade/3.1.1:
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
   /escape-string-regexp/1.0.5:
     dev: false
     engines:
@@ -1591,6 +1617,16 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  /wrap-ansi/7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.0
+      strip-ansi: 6.0.0
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   /wrappy/1.0.2:
     dev: false
     resolution:
@@ -1607,6 +1643,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+  /y18n/5.0.5:
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
   /yargs-parser/13.1.2:
     dependencies:
       camelcase: 5.3.1
@@ -1614,6 +1656,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  /yargs-parser/20.2.4:
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
   /yargs-unparser/1.6.0:
     dependencies:
       flat: 4.1.1
@@ -1639,6 +1687,20 @@ packages:
     dev: false
     resolution:
       integrity: sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  /yargs/16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.0
+      y18n: 5.0.5
+      yargs-parser: 20.2.4
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
   /yn/3.1.1:
     dev: false
     engines:
@@ -1649,16 +1711,18 @@ packages:
     dependencies:
       '@types/mocha': 7.0.2
       '@types/node': 14.0.27
+      '@types/yargs': 15.0.12
       '@typescript-eslint/eslint-plugin': 2.28.0_d62df2f848be5291fc9d2809dd11a3fb
       '@typescript-eslint/parser': 2.28.0_eslint@6.8.0+typescript@3.9.7
       eslint: 6.8.0
       mocha: 7.1.2
       ts-node: 8.10.2_typescript@3.9.7
       typescript: 3.9.7
+      yargs: 16.2.0
     dev: false
     name: '@rush-temp/adl.language'
     resolution:
-      integrity: sha512-EhPEpNogzgCZQTdSRTPlF6FkYo5LYGXd9FZcY2I38AVsNNubGHxLDizJLGww6E2YTkebiGTXIJm3TBNkZfeJyA==
+      integrity: sha512-5RfwV8T4dFMJLbqc00Dfc735bL/hpvcn0psIdYnFeS7h8CSFyWx4INn2gNoZUAnt1pPgX/Npdks6MkKWWs4/XQ==
       tarball: 'file:projects/adl.language.tgz'
     version: 0.0.0
 registry: ''
@@ -1666,9 +1730,11 @@ specifiers:
   '@rush-temp/adl.language': 'file:./projects/adl.language.tgz'
   '@types/mocha': ^7.0.2
   '@types/node': 14.0.27
+  '@types/yargs': ~15.0.12
   '@typescript-eslint/eslint-plugin': 2.28.0
   '@typescript-eslint/parser': 2.28.0
   eslint: 6.8.0
   mocha: 7.1.2
   ts-node: ^8.10.2
   typescript: ~3.9.5
+  yargs: ~16.2.0

--- a/packages/adl/compiler/options.ts
+++ b/packages/adl/compiler/options.ts
@@ -1,0 +1,3 @@
+export interface CompilerOptions {
+  swaggerOutputFile?: string;
+}

--- a/packages/adl/compiler/program.ts
+++ b/packages/adl/compiler/program.ts
@@ -1,7 +1,8 @@
 import { readdir, readFile } from 'fs/promises';
-import { join } from 'path';
+import { join, resolve as resolvePath } from 'path';
 import { createBinder, DecoratorSymbol, SymbolTable } from './binder.js';
 import { createChecker, MultiKeyMap } from './checker.js';
+import { CompilerOptions } from './options.js';
 import { parse } from './parser.js';
 import {
   ADLScriptNode,
@@ -15,6 +16,7 @@ import {
 } from './types.js';
 
 export interface Program {
+  compilerOptions: CompilerOptions;
   globalSymbols: SymbolTable;
   sourceFiles: Array<ADLSourceFile>;
   typeCache: MultiKeyMap<Type>;
@@ -34,10 +36,11 @@ export interface ADLSourceFile {
   interfaces: Array<InterfaceType>;
 }
 
-export async function compile(rootDir: string) {
+export async function compile(rootDir: string, options?: CompilerOptions) {
   const buildCbs: any = [];
 
   const program: Program = {
+    compilerOptions: options || {},
     globalSymbols: new Map(),
     sourceFiles: [],
     typeCache: new MultiKeyMap(),
@@ -208,6 +211,3 @@ export async function compile(rootDir: string) {
     }
   }
 }
-
-const dir = process.argv[2] || 'scratch';
-compile('./samples/' + dir).catch((e) => console.error(e));

--- a/packages/adl/lib/cli.ts
+++ b/packages/adl/lib/cli.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import yargs from "yargs";
+import { compile } from "../compiler/program.js";
+
+const args = yargs(process.argv.slice(2))
+  .help()
+  .strict()
+  .command(
+    "compile <path>",
+    "Compile a directory of ADL files.",
+    cmd => {
+      return cmd
+        .positional("path", {
+          description:
+            "The path to folder containing .adl files",
+          type: "string"
+        })
+        .option("output-file", {
+          type: "string",
+          describe: "The output file path for the OpenAPI document"
+        });
+    }
+  )
+  .option("debug", {
+    type: "boolean",
+    description: "Output debug log messages."
+  })
+  .option("verbose", {
+    alias: "v",
+    type: "boolean",
+    description: "Output verbose log messages."
+  })
+  .demandCommand(1, "You must use one of the supported commands.")
+  .argv;
+
+if (args._[0] === "compile" && args.path) {
+  try {
+    compile(args.path, {
+      swaggerOutputFile: args["output-file"]
+    });
+  } catch (err) {
+    console.error(`An error occurred while compiling path '${args.path}':\n\n${err}`);
+  }
+}

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { Program } from '../compiler/program.js';
 import { ArrayType, InterfaceType, InterfaceTypeProperty, ModelType, ModelTypeProperty, Type, UnionType } from '../compiler/types.js';
 import { getDoc } from './decorators.js';
@@ -10,9 +12,12 @@ import {
   isBody
 } from './rest.js';
 
-
 export function onBuild(p: Program) {
-  const emitter = createOAPIEmitter(p);
+  const options: OpenAPIEmitterOptions = {
+    outputFile: p.compilerOptions.swaggerOutputFile || path.resolve("./openapi.json")
+  };
+
+  const emitter = createOAPIEmitter(p, options);
   emitter.emitOpenAPI();
 }
 
@@ -21,7 +26,11 @@ export function operationId(program: Program, entity: Type, opId: string) {
   operationIds.set(entity, opId);
 }
 
-function createOAPIEmitter(program: Program) {
+export interface OpenAPIEmitterOptions {
+  outputFile: string;
+};
+
+function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   const root: any = {
     swagger: '2.0',
     info: {
@@ -59,7 +68,10 @@ function createOAPIEmitter(program: Program) {
     }
     emitReferences();
 
-    console.log(JSON.stringify(root, null, 4));
+    // Write out the OpenAPI document to the output path
+    fs.writeFileSync(
+      path.resolve(options.outputFile),
+      JSON.stringify(root, null, 4));
   }
 
   function emitResource(resource: InterfaceType) {

--- a/packages/adl/package.json
+++ b/packages/adl/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "ADL langauge",
   "main": "dist/main.js",
+  "bin": {
+    "adl": "dist/lib/cli.js"
+  },
   "engines": {
     "node": ">=10.12.0"
   },
@@ -37,8 +40,11 @@
     "eslint": "6.8.0",
     "mocha": "7.1.2",
     "ts-node": "^8.10.2",
-    "typescript": "~3.9.5"
+    "typescript": "~3.9.5",
+    "@types/yargs": "~15.0.12"
   },
-  "dependencies": {},
+  "dependencies": {
+    "yargs": "~16.2.0"
+  },
   "type": "module"
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -3,6 +3,8 @@
     "alwaysStrict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
This PR adds a basic CLI interface for the ADL compiler using the `yargs` library.  Here's an example of invoking it:

```
adl compile samples/ --output-file=swagger.json
```

I've introduced a new interface for `CompilerOptions`, let me know if you think there's a better way to express this!

Part of #216.