### PR TITLE
Improve templated intrinsic types in OpenAPI emitter, add more decorators

### DIFF
--- a/packages/adl/compiler/checker.ts
+++ b/packages/adl/compiler/checker.ts
@@ -382,7 +382,8 @@ export function createChecker(program: Program) {
         const type: ModelType = createType({
           ... <ModelType>assignmentType,
           node: node,
-          name: (<ModelStatementNode>node).id.sv
+          name: (<ModelStatementNode>node).id.sv,
+          assignmentType
         });
 
         return type;

--- a/packages/adl/lib/cli.ts
+++ b/packages/adl/lib/cli.ts
@@ -35,11 +35,9 @@ const args = yargs(process.argv.slice(2))
   .argv;
 
 if (args._[0] === "compile" && args.path) {
-  try {
-    compile(args.path, {
-      swaggerOutputFile: args["output-file"]
-    });
-  } catch (err) {
-    console.error(`An error occurred while compiling path '${args.path}':\n\n${err}`);
-  }
+  compile(args.path, {
+    swaggerOutputFile: args["output-file"]
+  }).catch((err) => {
+    console.error(`An error occurred while compiling path '${args.path}':\n\n${err.message}`);
+  });
 }

--- a/packages/adl/lib/decorators.ts
+++ b/packages/adl/lib/decorators.ts
@@ -29,3 +29,85 @@ export function intrinsic(program: Program, target: Type) {
 export function isIntrinsic(target: Type) {
   return intrinsics.has(target);
 }
+
+// Walks the assignmentType chain to find the core intrinsic type, if any
+export function getIntrinsicType(target: Type | undefined): string | undefined {
+  while (target) {
+    if (target.kind === "Model") {
+      if (isIntrinsic(target)) {
+        return target.name;
+      }
+
+      target =
+        (target.assignmentType?.kind === "Model" && target.assignmentType)
+        || undefined;
+    } else {
+      break;
+    }
+  }
+
+  return undefined;
+}
+
+// -- @format decorator ---------------------
+
+const formatValues = new Map<Type, string>();
+
+export function format(program: Program, target: Type, format: string) {
+  if (target.kind === "Model") {
+    // Is it a model type that ultimately derives from 'string'?
+    if (getIntrinsicType(target) === "string") {
+      formatValues.set(target, format);
+    } else {
+      throw new Error("Cannot apply @format to a non-string type");
+    }
+  } else {
+    throw new Error("Cannot apply @format to anything that isn't a Model");
+  }
+}
+
+export function getFormat(target: Type): string | undefined {
+  return formatValues.get(target);
+}
+
+// -- @minLength decorator ---------------------
+
+const minLengthValues = new Map<Type, number>();
+
+export function minLength(program: Program, target: Type, minLength: number) {
+  if (target.kind === "Model") {
+    // Is it a model type that ultimately derives from 'string'?
+    if (getIntrinsicType(target) === "string") {
+      minLengthValues.set(target, minLength);
+    } else {
+      throw new Error("Cannot apply @minLength to a non-string type");
+    }
+  } else {
+    throw new Error("Cannot apply @format to anything that isn't a Model");
+  }
+}
+
+export function getMinLength(target: Type): number | undefined {
+  return minLengthValues.get(target);
+}
+
+// -- @maxLength decorator ---------------------
+
+const maxLengthValues = new Map<Type, number>();
+
+export function maxLength(program: Program, target: Type, maxLength: number) {
+  if (target.kind === "Model") {
+    // Is it a model type that ultimately derives from 'string'?
+    if (getIntrinsicType(target) === "string") {
+      maxLengthValues.set(target, maxLength);
+    } else {
+      throw new Error("Cannot apply @maxLength to a non-string type");
+    }
+  } else {
+    throw new Error("Cannot apply @format to anything that isn't a Model");
+  }
+}
+
+export function getMaxLength(target: Type): number | undefined {
+  return maxLengthValues.get(target);
+}

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -631,9 +631,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       case 'Boolean':
         return { type: 'boolean', enum: [adlType.value] };
       case 'Model':
-        // Is the type templated?
-        if (adlType.baseModels.length > 0 && !hasSchemaProperties(adlType.ownProperties)) {
-          // NOTE: Arbitrarily picking first type for now
+        // Is the type templated with only one type?
+        if (adlType.baseModels.length === 1 && !hasSchemaProperties(adlType.ownProperties)) {
           return mapADLTypeToOpenAPI(adlType.baseModels[0]);
         }
 

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Program } from '../compiler/program.js';
 import { ArrayType, InterfaceType, InterfaceTypeProperty, ModelType, ModelTypeProperty, Type, UnionType } from '../compiler/types.js';
-import { getDoc } from './decorators.js';
+import { getDoc, getFormat, getIntrinsicType, getMaxLength, getMinLength } from './decorators.js';
 import {
   basePathForResource,
   getHeaderFieldName,
@@ -73,7 +73,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     // Write out the OpenAPI document to the output path
     fs.writeFileSync(
       path.resolve(options.outputFile),
-      JSON.stringify(root, null, 4));
+      JSON.stringify(root, null, 2));
   }
 
   function emitResource(resource: InterfaceType) {
@@ -231,7 +231,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
             }
             break;
           case 'content-type':
-            if (type.kind === "String" ){
+            if (type.kind === "String") {
               contentType = type.value;
             }
             break;
@@ -579,7 +579,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     if (type.kind === 'Model') {
       type = getTypeForSchemaProperties(type);
       if (!hasSchemaProperties(type.properties)) {
-        return "{}";
+        return getIntrinsicType(type) || "{}";
       }
     }
     return program!.checker!.getTypeName(type);
@@ -594,7 +594,35 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     return false;
   }
 
-  function mapADLTypeToOpenAPI(adlType: Type) {
+  function applyStringDecorators(adlType: Type, schemaType: any): any {
+    const pattern = getFormat(adlType);
+    if (schemaType.type === "string" && !schemaType.format && pattern) {
+      schemaType = {
+        ...schemaType,
+        pattern
+      };
+    }
+
+    const minLength = getMinLength(adlType);
+    if (schemaType.type === "string" && !schemaType.minLength && minLength) {
+      schemaType = {
+        ...schemaType,
+        minLength
+      };
+    }
+
+    const maxLength = getMaxLength(adlType);
+    if (schemaType.type === "string" && !schemaType.maxLength && maxLength) {
+      schemaType = {
+        ...schemaType,
+        maxLength
+      };
+    }
+
+    return schemaType;
+  }
+
+  function mapADLTypeToOpenAPI(adlType: Type): any {
     switch (adlType.kind) {
       case 'Number':
         return { type: 'number', enum: [adlType.value] };
@@ -603,6 +631,12 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       case 'Boolean':
         return { type: 'boolean', enum: [adlType.value] };
       case 'Model':
+        // Is the type templated?
+        if (adlType.baseModels.length > 0 && !hasSchemaProperties(adlType.ownProperties)) {
+          // NOTE: Arbitrarily picking first type for now
+          return mapADLTypeToOpenAPI(adlType.baseModels[0]);
+        }
+
         switch (adlType.name) {
           case 'int32':
             return { type: 'integer', format: 'int32' };
@@ -611,11 +645,18 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
           case 'float64':
             return { type: 'number' };
           case 'string':
-            return { type: 'string' };
+            // Return a string schema augmented by decorators
+            return applyStringDecorators(adlType, { type: 'string' });
           case 'boolean':
             return { type: 'boolean' };
           case 'date':
             return { type: 'string', format: 'date' };
+          default:
+            // Recursively call this function to find the underlying OpenAPI type
+            if (adlType.assignmentType) {
+              return applyStringDecorators(adlType, mapADLTypeToOpenAPI(adlType.assignmentType));
+            }
+            break;
         }
       // fallthrough
       default:


### PR DESCRIPTION
This change addresses #242 and resolves #229 and #240:

- Templated types like `Ok<string>` or `Ok<someTypeAssignedFromIntrinsic>` will now be correctly represented in operation response schemas
- Added `@format` decorator for pattern-based validation of string parameters
- Added `@minLength` and `@maxLength` decorators for validation of string parameter length

**Questions**

- Should `@format` be `@pattern` or something else?  I was following the naming convention in @markcowl's `confluence.adl` example

**Contrived Example**

**`sample.adl`**:

```
@doc "Success"
model Ok<T> {
  @header statusCode: 200;
  ... T;
}

@doc "Client Error"
model ClientError<T> {
  @header statusCode: 400;
  ... T;
}

@resource("/resources/organization")
interface Organization {
  @get getKeys(): Ok<email>;
  @post postKey(addr: email): Ok<string>;
  @put updateKey(key: string25): ClientError<int64>;
  @_delete deleteKey(key: string50): Ok<string>;
}

@doc("Reusable representation of an email address")
@format("\\w+@\\w+\\.\\w+")
model email = string;

@doc('Shorthand for setting length limit.')
@minLength(5)
@maxLength(50)
model string50 = string;

@doc("Shorthand for setting length limit.")
@maxLength(25)
model string25 = string;
```

**`openapi.json`**:

```json
{
  "swagger": "2.0",
  "info": {
    "title": "(title)",
    "version": "0000-00-00"
  },
  "schemes": [
    "https"
  ],
  "paths": {
    "/resources/organization": {
      "get": {
        "consumes": [],
        "produces": [
          "application/json"
        ],
        "parameters": [],
        "responses": {
          "200": {
            "schema": {
              "type": "string",
              "pattern": "\\w+@\\w+\\.\\w+"
            },
            "description": "Success"
          }
        }
      },
      "post": {
        "consumes": [
          "application/json"
        ],
        "produces": [
          "application/json"
        ],
        "parameters": [
          {
            "name": "addr",
            "in": "body",
            "required": true,
            "schema": {
              "type": "string",
              "pattern": "\\w+@\\w+\\.\\w+"
            }
          }
        ],
        "responses": {
          "200": {
            "schema": {
              "type": "string"
            },
            "description": "Success"
          }
        }
      },
      "put": {
        "consumes": [
          "application/json"
        ],
        "produces": [
          "application/json"
        ],
        "parameters": [
          {
            "name": "key",
            "in": "body",
            "required": true,
            "schema": {
              "type": "string",
              "maxLength": 25
            }
          }
        ],
        "responses": {
          "400": {
            "schema": {
              "type": "integer",
              "format": "int64"
            },
            "description": "Client Error"
          }
        }
      },
      "delete": {
        "consumes": [
          "application/json"
        ],
        "produces": [
          "application/json"
        ],
        "parameters": [
          {
            "name": "key",
            "in": "body",
            "required": true,
            "schema": {
              "type": "string",
              "minLength": 5,
              "maxLength": 50
            }
          }
        ],
        "responses": {
          "200": {
            "schema": {
              "type": "string"
            },
            "description": "Success"
          }
        }
      }
    }
  },
  "definitions": {},
  "parameters": {}
}
```