### PR TITLE
Add @secret and @visibility decorators, minor clean-up

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,6 +6,7 @@ dependencies:
   '@types/yargs': 15.0.12
   '@typescript-eslint/eslint-plugin': 2.28.0_d62df2f848be5291fc9d2809dd11a3fb
   '@typescript-eslint/parser': 2.28.0_eslint@6.8.0+typescript@3.9.7
+  autorest: 3.0.6322
   eslint: 6.8.0
   mkdirp: 1.0.4
   mocha: 7.1.2
@@ -237,6 +238,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+  /autorest/3.0.6322:
+    dev: false
+    engines:
+      node: '>=10.13.0'
+    hasBin: true
+    requiresBuild: true
+    resolution:
+      integrity: sha512-q0W5FD8TmxCqpPiD9fXGPbt+DCyf3brGvAAnzoFSngcaBgwy/CfvUVVXbwcHEUYzFive++tpQwM6Q0SFHEfKbQ==
   /balanced-match/1.0.0:
     dev: false
     resolution:
@@ -1730,6 +1739,7 @@ packages:
       '@types/yargs': 15.0.12
       '@typescript-eslint/eslint-plugin': 2.28.0_d62df2f848be5291fc9d2809dd11a3fb
       '@typescript-eslint/parser': 2.28.0_eslint@6.8.0+typescript@3.9.7
+      autorest: 3.0.6322
       eslint: 6.8.0
       mkdirp: 1.0.4
       mocha: 7.1.2
@@ -1739,7 +1749,7 @@ packages:
     dev: false
     name: '@rush-temp/adl.language'
     resolution:
-      integrity: sha512-5pIxzhzb2BWZLwGZpFHfuwS+EcfE4SkXWsDMXp8OJBJRt3T0mPSW+tMXMBxup9vLj6ias4pOJ24dwFwwo3+xyg==
+      integrity: sha512-JUdt5fJ8X6Bnexg9DNQVbolKMOG7WSw7EGGpbTxpF5xkW/cYmM/MWcV5mKCqXHe+GAta/a8uUJyAks6wd8sEfw==
       tarball: 'file:projects/adl.language.tgz'
     version: 0.0.0
 registry: ''
@@ -1751,6 +1761,7 @@ specifiers:
   '@types/yargs': ~15.0.12
   '@typescript-eslint/eslint-plugin': 2.28.0
   '@typescript-eslint/parser': 2.28.0
+  autorest: ~3.0.6322
   eslint: 6.8.0
   mkdirp: ~1.0.4
   mocha: 7.1.2

--- a/packages/adl/lib/cli.ts
+++ b/packages/adl/lib/cli.ts
@@ -22,6 +22,7 @@ const args = yargs(process.argv.slice(2))
         })
         .option("output-path", {
           type: "string",
+          default: "./adl-output",
           describe: "The output path for generated artifacts.  If it does not exist, it will be created."
         });
     }
@@ -38,12 +39,12 @@ const args = yargs(process.argv.slice(2))
         })
         .option("client", {
           type: "boolean",
-          describe: "The output file path for the generated client"
+          describe: "Generate a client library for the ADL definition"
         })
         .option("output-path", {
           type: "string",
           default: "./adl-output",
-          describe: "The output file path for the generated client"
+          describe: "The output path for generated artifacts.  If it does not exist, it will be created."
         });
     }
   )
@@ -107,4 +108,11 @@ async function main() {
   }
 }
 
-main().then(() => {});
+main()
+  .then(() => {})
+  .catch((err) => {
+    console.error(`An unknown error occurred:\n\n${err.message}`);
+    if (args["debug"]) {
+      console.error(`Stack trace:\n\n${err.stack}`);
+    }
+  });

--- a/packages/adl/lib/cli.ts
+++ b/packages/adl/lib/cli.ts
@@ -94,7 +94,10 @@ async function main() {
 
       // Execute AutoRest on the output file
       // TODO: Parameterize client language selection
-      spawnSync("autorest", [
+      spawnSync(
+        process.platform === "win32"
+          ? "autorest.cmd"
+          : "autorest", [
         "--version:3.0.6367",
         "--typescript",
         `--clear-output-folder=true`,
@@ -102,7 +105,8 @@ async function main() {
         `--title=AdlClient`,
         `--input-file=${options.swaggerOutputFile}`
       ], {
-        stdio: 'inherit'
+          stdio: 'inherit',
+          shell: true
       });
     }
   }

--- a/packages/adl/lib/cli.ts
+++ b/packages/adl/lib/cli.ts
@@ -91,13 +91,16 @@ async function main() {
 
     if (args.client) {
       const clientPath = path.resolve(args["output-path"], "client");
+      const autoRestPath = path.resolve(
+        "node_modules/.bin",
+        process.platform === "win32"
+          ? "autorest.cmd"
+          : "autorest"
+      );
 
       // Execute AutoRest on the output file
       // TODO: Parameterize client language selection
-      spawnSync(
-        process.platform === "win32"
-          ? "autorest.cmd"
-          : "autorest", [
+      spawnSync(autoRestPath, [
         "--version:3.0.6367",
         "--typescript",
         `--clear-output-folder=true`,

--- a/packages/adl/lib/decorators.ts
+++ b/packages/adl/lib/decorators.ts
@@ -83,7 +83,7 @@ export function minLength(program: Program, target: Type, minLength: number) {
       throw new Error("Cannot apply @minLength to a non-string type");
     }
   } else {
-    throw new Error("Cannot apply @format to anything that isn't a Model");
+    throw new Error("Cannot apply @minLength to anything that isn't a Model");
   }
 }
 
@@ -104,10 +104,32 @@ export function maxLength(program: Program, target: Type, maxLength: number) {
       throw new Error("Cannot apply @maxLength to a non-string type");
     }
   } else {
-    throw new Error("Cannot apply @format to anything that isn't a Model");
+    throw new Error("Cannot apply @maxLength to anything that isn't a Model");
   }
 }
 
 export function getMaxLength(target: Type): number | undefined {
   return maxLengthValues.get(target);
 }
+
+// -- @secret decorator ---------------------
+
+const secretTypes = new Map<Type, boolean>();
+
+export function secret(program: Program, target: Type) {
+  if (target.kind === "Model") {
+    // Is it a model type that ultimately derives from 'string'?
+    if (getIntrinsicType(target) === "string") {
+      secretTypes.set(target, true);
+    } else {
+      throw new Error("Cannot apply @secret to a non-string type");
+    }
+  } else {
+    throw new Error("Cannot apply @secret to anything that isn't a Model");
+  }
+}
+
+export function isSecret(target: Type): boolean | undefined {
+  return secretTypes.get(target);
+}
+

--- a/packages/adl/lib/decorators.ts
+++ b/packages/adl/lib/decorators.ts
@@ -133,3 +133,25 @@ export function isSecret(target: Type): boolean | undefined {
   return secretTypes.get(target);
 }
 
+// -- @visibility decorator ---------------------
+
+export type VisibilityLevels = 'read' | 'write';
+const visibilityLevels = ['read', 'write'];
+
+const visibilitySettings = new Map<Type, VisibilityLevels>();
+
+export function visibility(program: Program, target: Type, visibility: VisibilityLevels) {
+  if (target.kind === "ModelProperty") {
+    if (visibilityLevels.indexOf(visibility) < 0) {
+      throw new Error(`Invalid @visibility value: ${visibility}.  Must be one of ${visibilityLevels}.`)
+    }
+
+    visibilitySettings.set(target, visibility);
+  } else {
+    throw new Error("The @visibility decorator can only be applied to model properties.");
+  }
+}
+
+export function getVisibility(target: Type): VisibilityLevels | undefined {
+  return visibilitySettings.get(target);
+}

--- a/packages/adl/lib/decorators.ts
+++ b/packages/adl/lib/decorators.ts
@@ -135,23 +135,16 @@ export function isSecret(target: Type): boolean | undefined {
 
 // -- @visibility decorator ---------------------
 
-export type VisibilityLevels = 'read' | 'write';
-const visibilityLevels = ['read', 'write'];
+const visibilitySettings = new Map<Type, string>();
 
-const visibilitySettings = new Map<Type, VisibilityLevels>();
-
-export function visibility(program: Program, target: Type, visibility: VisibilityLevels) {
+export function visibility(program: Program, target: Type, visibility: string) {
   if (target.kind === "ModelProperty") {
-    if (visibilityLevels.indexOf(visibility) < 0) {
-      throw new Error(`Invalid @visibility value: ${visibility}.  Must be one of ${visibilityLevels}.`)
-    }
-
     visibilitySettings.set(target, visibility);
   } else {
     throw new Error("The @visibility decorator can only be applied to model properties.");
   }
 }
 
-export function getVisibility(target: Type): VisibilityLevels | undefined {
+export function getVisibility(target: Type): string | undefined {
   return visibilitySettings.get(target);
 }

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Program } from '../compiler/program.js';
 import { ArrayType, InterfaceType, InterfaceTypeProperty, ModelType, ModelTypeProperty, Type, UnionType } from '../compiler/types.js';
-import { getDoc, getFormat, getIntrinsicType, getMaxLength, getMinLength } from './decorators.js';
+import { getDoc, getFormat, getIntrinsicType, getMaxLength, getMinLength, isSecret } from './decorators.js';
 import {
   basePathForResource,
   getHeaderFieldName,
@@ -620,6 +620,13 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         ...schemaType,
         maxLength
       };
+    }
+
+    if (isSecret(adlType)) {
+      schemaType = {
+        ...schemaType,
+        format: "password"
+      }
     }
 
     return schemaType;

--- a/packages/adl/package.json
+++ b/packages/adl/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "yargs": "~16.2.0",
     "mkdirp": "~1.0.4",
-    "@types/mkdirp": "~1.0.1"
+    "@types/mkdirp": "~1.0.1",
+    "autorest": "~3.0.6322"
   },
   "type": "module"
 }

--- a/packages/adl/samples/confluent/confluent.adl
+++ b/packages/adl/samples/confluent/confluent.adl
@@ -1,3 +1,23 @@
+@doc("A string that represents a URI.")
+model Uri = string;
+
+@doc("Reusable representation of an email address")
+@format("\\w+@\\w+\\.\\w+")
+model email = string;
+
+@doc('Shorthand for setting length limit.')
+@minLength(5)
+@maxLength(50)
+model string50 = string;
+
+@doc("Shorthand for setting length limit.")
+@maxLength(25)
+model string25 = string;
+
+@doc("An Organization key to be handled as a secret.")
+@secret
+model OrganizationKey = string;
+
 @TrackedResource("Microsoft.Confluent/organizations", OrganizationProperties)
 interface Organization {
   @post getKeys(@path subscriptionId: string, @path resourceGroup: string, @path name: string) : ArmResponse<OrganizationKeys>;
@@ -6,15 +26,15 @@ interface Organization {
 @doc("Details of the Confluent organization.")
 model OrganizationProperties {
   @doc("UTC Time when Organization resource was created.")
-  // @visibility('read') 
+  @visibility('read')
   createdTime: date;
 
   @doc("Id of the Confluent organization.")
-  // @visibility('read') 
+  @visibility('read')
   organizationId: string;
 
   @doc("Single sign-on url for the Confluent organization.")
-  // @visibility('read') 
+  @visibility('read')
   ssoUrl: Uri;
 
   @doc("Details of the product offering.")
@@ -23,11 +43,6 @@ model OrganizationProperties {
   @doc("Subscriber details.")
   userDetail: UserDetail;
 }
-
-// @doc("Details of the Confluent organization (read only properties)")
-// @withVisibility("read")
-// model OrganizationReadProperties {
-// }
 
 @doc("Details of the product offering.")
 model OfferDetail {
@@ -72,22 +87,7 @@ model OrganizationKeys {
   secondary: OrganizationKey;
 }
 
-@doc("A string that represents a URI.")
-model Uri = string;
-
-@doc("Reusable representation of an email address")
-@format("\\w+@\\w+\\.\\w+")
-model email = string;
-
-@doc('Shorthand for setting length limit.')
-@minLength(5)
-@maxLength(50)
-model string50 = string;
-
-@doc("Shorthand for setting length limit.")
-@maxLength(25)
-model string25 = string;
-
-@doc("An Organization key to be handled as a secret.")
-@secret
-model OrganizationKey = string;
+// @doc("Details of the Confluent organization (read only properties)")
+// @withVisibility("read")
+// model OrganizationReadProperties {
+// }

--- a/packages/adl/samples/confluent/confluent.adl
+++ b/packages/adl/samples/confluent/confluent.adl
@@ -7,7 +7,6 @@ interface Organization {
 model OrganizationProperties {
   @doc("UTC Time when Organization resource was created.")
   // @visibility('read') 
-  // createdTime: DateTime;
   createdTime: date;
 
   @doc("Id of the Confluent organization.")
@@ -16,8 +15,7 @@ model OrganizationProperties {
 
   @doc("Single sign-on url for the Confluent organization.")
   // @visibility('read') 
-  // ssoUrl: Uri;
-  ssoUrl: string;
+  ssoUrl: Uri;
 
   @doc("Details of the product offering.")
   offerDetail: OfferDetail;
@@ -68,13 +66,14 @@ model UserDetail {
 
 model OrganizationKeys {
   @doc("The primary key.")
-  // primary: SecureString;
-  primary: string;
+  primary: OrganizationKey;
 
   @doc("The secondary Key.")
-  // secondary: SecureString;
-  secondary: string;
+  secondary: OrganizationKey;
 }
+
+@doc("A string that represents a URI.")
+model Uri = string;
 
 @doc("Reusable representation of an email address")
 @format("\\w+@\\w+\\.\\w+")
@@ -88,3 +87,7 @@ model string50 = string;
 @doc("Shorthand for setting length limit.")
 @maxLength(25)
 model string25 = string;
+
+@doc("An Organization key to be handled as a secret.")
+@secret
+model OrganizationKey = string;


### PR DESCRIPTION
This change adds the `@secret` and `@visibility` decorators to complete the set for the Confluent demo.  I'm using `@secret` here in the place of `SecureString` based on the discussion we had in Teams last week.  Also, `@visibility` information currently isn't getting used, I can try adding that before merging.

Also did some general cleanup in a couple places and rearranged the `confluent.adl` file to have a better flow for demos.