### PR TITLE
Add support for x-ms-pageable and arbitrary OpenAPI extensions

### DIFF
--- a/packages/adl/lib/arm.adl
+++ b/packages/adl/lib/arm.adl
@@ -19,7 +19,7 @@ model ArmTrackedResource<TProperties> {
 }
 
 @doc("Response envelope for ARM operations.")
-model ArmResponse<T> {
+model ArmResponseBase {
   @header statusCode: 200;
 
   @header("x-ms-client-request-id")
@@ -27,6 +27,17 @@ model ArmResponse<T> {
 
   @header("x-ms-correlation-request-id")
   correlationRequestId: string;
+}
 
+@doc("Typed response envelope for ARM operations.")
+model ArmResponse<T> {
+  ... ArmResponseBase;
   ... T;
+}
+
+@doc("Paged response")
+model Page<T> {
+  ... ArmResponseBase;
+  value: T[];
+  nextLink: string;
 }

--- a/packages/adl/lib/arm.ts
+++ b/packages/adl/lib/arm.ts
@@ -39,12 +39,12 @@ export function TrackedResource(
 
          @resource("/subscriptions/{subscriptionId}/providers/${resourceRoot}")
          interface ${target.name}ListAll {
-           @pageable @get listAll(@path subscriptionId: string): Page<${resourceModelName}>;
+           @list @get listAll(@path subscriptionId: string): Page<${resourceModelName}>;
          }
 
          @resource("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/${resourceRoot}")
          interface ${target.name}List {
-           @pageable @get listByResourceGroup(@path subscriptionId: string, @path resourceGroup: string): Page<${resourceModelName}>;
+           @list @get listByResourceGroup(@path subscriptionId: string, @path resourceGroup: string): Page<${resourceModelName}>;
          }
       `);
 

--- a/packages/adl/lib/decorators.ts
+++ b/packages/adl/lib/decorators.ts
@@ -148,3 +148,19 @@ export function visibility(program: Program, target: Type, visibility: string) {
 export function getVisibility(target: Type): string | undefined {
   return visibilitySettings.get(target);
 }
+
+// -- @list decorator ---------------------
+
+const listProperties = new Set<Type>();
+
+export function list(program: Program, target: Type) {
+  if (target.kind === "InterfaceProperty" || target.kind === "ModelProperty") {
+    listProperties.add(target);
+  } else {
+    throw new Error("The @list decorator can only be applied to interface or model properties.");
+  }
+}
+
+export function isList(target: Type): boolean {
+  return listProperties.has(target);
+}

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -28,6 +28,26 @@ export function operationId(program: Program, entity: Type, opId: string) {
   operationIds.set(entity, opId);
 }
 
+const pageableOperations = new Map<Type, string>();
+export function pageable(program: Program, entity: Type, nextLinkName: string = "nextLink") {
+  pageableOperations.set(entity, nextLinkName);
+}
+
+function getPageable(entity: Type): string | undefined {
+  return pageableOperations.get(entity);
+}
+
+const openApiExtensions = new Map<Type, Map<string, any>>();
+export function extension(program: Program, entity: Type, extensionName: string, value: any) {
+  let typeExtensions = openApiExtensions.get(entity) ?? new Map<string, any>();
+  typeExtensions.set(extensionName, value);
+  openApiExtensions.set(entity, typeExtensions);
+}
+
+function getExtensions(entity: Type): Map<string, any> {
+  return openApiExtensions.get(entity) ?? new Map<string, any>();
+}
+
 export interface OpenAPIEmitterOptions {
   outputFile: string;
 };
@@ -181,6 +201,13 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     currentEndpoint.produces = [];
     currentEndpoint.parameters = [];
     currentEndpoint.responses = {};
+
+    const nextLinkName = getPageable(prop);
+    if (nextLinkName) {
+      currentEndpoint["x-ms-pageable"] = {
+        nextLinkName
+      }
+    }
 
     emitEndpointParameters(
       prop.parameters,
@@ -527,6 +554,16 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         }
       }
     }
+
+    // Attach any OpenAPI extensions
+    const extensions = getExtensions(model);
+    if (extensions) {
+      for (const key of extensions.keys()) {
+        // console.log("Adding extension", key, extensions.get(key));
+        modelSchema[key] = extensions.get(key);
+      }
+    }
+
     return modelSchema;
   }
 

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Program } from '../compiler/program.js';
 import { ArrayType, InterfaceType, InterfaceTypeProperty, ModelType, ModelTypeProperty, Type, UnionType } from '../compiler/types.js';
-import { getDoc, getFormat, getIntrinsicType, getMaxLength, getMinLength, isSecret } from './decorators.js';
+import { getDoc, getFormat, getIntrinsicType, getMaxLength, getMinLength, isSecret, isList } from './decorators.js';
 import {
   basePathForResource,
   getHeaderFieldName,
@@ -202,10 +202,12 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     currentEndpoint.parameters = [];
     currentEndpoint.responses = {};
 
-    const nextLinkName = getPageable(prop);
-    if (nextLinkName) {
-      currentEndpoint["x-ms-pageable"] = {
-        nextLinkName
+    if (isList(prop)) {
+      const nextLinkName = getPageable(prop) || "nextLink";
+      if (nextLinkName) {
+        currentEndpoint["x-ms-pageable"] = {
+          nextLinkName
+        }
       }
     }
 

--- a/packages/adl/samples/confluent/confluent.adl
+++ b/packages/adl/samples/confluent/confluent.adl
@@ -8,11 +8,11 @@ model email = string;
 @doc('Shorthand for setting length limit.')
 @minLength(5)
 @maxLength(50)
-model string50 = string;
+model MediumString = string;
 
 @doc("Shorthand for setting length limit.")
 @maxLength(25)
-model string25 = string;
+model ShortString = string;
 
 @doc("An Organization key to be handled as a secret.")
 @secret
@@ -47,19 +47,19 @@ model OrganizationProperties {
 @doc("Details of the product offering.")
 model OfferDetail {
   @doc("Id of the product publisher.")
-  publisherId: string50;
+  publisherId: MediumString;
 
   @doc("Id of the product offering.")
-  id: string50;
+  id: MediumString;
 
   @doc("Id of the product offer plan.")
-  planId: string50;
+  planId: MediumString;
 
   @doc("Name of the product offer plan.")
-  planName: string50;
+  planName: MediumString;
 
   @doc("Offer plan term unit.")
-  termUnit: string25;
+  termUnit: ShortString;
   
   @doc("SaaS offer status.")
   status: 'Started' | 'PendingFulfillmentStart' | 'InProgress' |
@@ -70,10 +70,10 @@ model OfferDetail {
 @doc("Details of the subscriber")
 model UserDetail {
   @doc("Subscriber first name.")
-  firstName: string50;
+  firstName: MediumString;
 
   @doc("Subscriber last name.")
-  lastName: string50;
+  lastName: MediumString;
 
   @doc("Subscriber email address.")
   emailAddress: email

--- a/packages/adl/samples/petstore/petstore.adl
+++ b/packages/adl/samples/petstore/petstore.adl
@@ -1,18 +1,8 @@
-@doc "Success"
-model Ok<T> {
-  @header statusCode: 200;
-  ... T;
-}
+// Model types
 
 model Pet {
   name: string;
   tag?: string;
-}
-
-@doc "Error"
-model Error {
-  code: int32;
-  message: string;
 }
 
 model Toy {
@@ -21,13 +11,27 @@ model Toy {
   name: string;
 }
 
+// Response types
+
+@doc "Success"
+model Ok<T> {
+  @header statusCode: 200;
+  ... T;
+}
+
+@doc "Error"
+model Error {
+  code: int32;
+  message: string;
+}
+
 @doc "Not modified"
 model NotModified<T> {
   @header statusCode: 304;
   ... T;
 }
 
-model Page<T> {
+model ResponsePage<T> {
   items: T[];
   nextLink: string;
 }
@@ -38,12 +42,13 @@ model PetId {
 
 @doc "Manage your pets."
 @resource "/pets"
-interface PetsResource {
+interface Pets {
   @doc "Delete a pet."
   delete(... PetId): Ok<{}> | Error;
 
   @fancyDoc "List pets."
-  list(@query nextLink?: string): Ok<Page<Pet>> | Error;
+  @pageable
+  list(@query nextLink?: string): Ok<ResponsePage<Pet>> | Error;
 
   @doc "Returns a pet. Supports eTags."
   read(... PetId): Ok<Pet> | NotModified<Pet> | Error;
@@ -53,5 +58,6 @@ interface PetsResource {
 
 @resource "/pets/{petId}/toys"
 interface ListPetToysResponse {
-  list(@path petId: string, @query nameFilter: string): Ok<Page<Toy>> | Error;
+  @pageable
+  list(@path petId: string, @query nameFilter: string): Ok<ResponsePage<Toy>> | Error;
 }

--- a/packages/adl/samples/petstore/petstore.adl
+++ b/packages/adl/samples/petstore/petstore.adl
@@ -47,7 +47,7 @@ interface Pets {
   delete(... PetId): Ok<{}> | Error;
 
   @fancyDoc "List pets."
-  @pageable
+  @list
   list(@query nextLink?: string): Ok<ResponsePage<Pet>> | Error;
 
   @doc "Returns a pet. Supports eTags."
@@ -58,6 +58,6 @@ interface Pets {
 
 @resource "/pets/{petId}/toys"
 interface ListPetToysResponse {
-  @pageable
+  @list
   list(@path petId: string, @query nameFilter: string): Ok<ResponsePage<Toy>> | Error;
 }


### PR DESCRIPTION
This change adds support for `x-ms-pageable` in the OpenAPI emitter via the `@pageable` decorator.  The idea is that the ADL author can mark an operation as being pageable and also identify the name of the response property containing the next link URL for paging purposes.  This is very specific to OpenAPI so we might need to consider coming up with a more general way to express this in the future.

I also added the `@extension()` decorator for attaching `x-*` extensions to elements of the Swagger document.  Currently I'm only applying them to model types, need to figure out the remaining places where they should go (I'll file an issue for that).  This decorator enabled me to add `"x-ms-azure-resource": true` to generated ARM resource model types.

Also including some cleanup I did to our example ADL files as a result of this, let me know if you want me to change any of that!