### PR TITLE
Remove some redundant language constructs

### DIFF
--- a/packages/adl/compiler/parser.ts
+++ b/packages/adl/compiler/parser.ts
@@ -58,7 +58,7 @@ export function parse(code: string) {
   function parseDecoratorList() {
     const decorators: Array<Types.DecoratorExpressionNode> = [];
 
-    while (token() === Kind.At || token() === Kind.OpenBracket) {
+    while (token() === Kind.At) {
       decorators.push(parseDecoratorExpression());
     }
 
@@ -383,14 +383,7 @@ export function parse(code: string) {
 
   function parseDecoratorExpression(): Types.DecoratorExpressionNode {
     const pos = tokenPos();
-    let usesBrackets = false;
-
-    if (token() === Kind.OpenBracket) {
-      usesBrackets = true;
-      parseExpected(Kind.OpenBracket);
-    } else {
-      parseExpected(Kind.At);
-    }
+    parseExpected(Kind.At);
 
     const target = parseMemberExpression();
 
@@ -407,10 +400,6 @@ export function parse(code: string) {
       }
     } else if (tokenIsLiteral()) {
       args = [parsePrimaryExpression()];
-    }
-
-    if (usesBrackets) {
-      parseExpected(Kind.CloseBracket);
     }
 
     return finishNode({

--- a/packages/adl/compiler/parser.ts
+++ b/packages/adl/compiler/parser.ts
@@ -41,11 +41,6 @@ export function parse(code: string) {
           return parseModelStatement(decorators);
         case Kind.InterfaceKeyword:
           return parseInterfaceStatement(decorators);
-        case Kind.AliasKeyword:
-          if (decorators.length > 0) {
-            error('Cannot decorate an alias statement');
-          }
-          return parseAliasStatement();
         case Kind.Semicolon:
           if (decorators.length > 0) {
             error('Cannot decorate an empty statement');
@@ -550,23 +545,6 @@ export function parse(code: string) {
     }, pos);
   }
 
-  function parseAliasStatement(): Types.AliasStatementNode {
-    const pos = tokenPos();
-    parseExpected(Kind.AliasKeyword);
-
-    const id = parseIdentifier();
-    parseExpected(Kind.Colon);
-
-    const target = parseExpression();
-    parseExpected(Kind.Semicolon);
-
-    return finishNode({
-      kind: Types.SyntaxKind.AliasStatement,
-      id,
-      target
-    }, pos);
-  }
-
   // utility functions
   function token() {
     return scanner.token;
@@ -668,9 +646,6 @@ export function visitChildren<T>(node: Types.Node, cb: NodeCb<T>): T | undefined
   switch (node.kind) {
     case Types.SyntaxKind.ADLScript:
       return visitEach(cb, (<Types.ADLScriptNode>node).statements);
-    case Types.SyntaxKind.AliasStatement:
-      return visitNode(cb, (<Types.AliasStatementNode>node).id) ||
-        visitNode(cb, (<Types.AliasStatementNode>node).target);
     case Types.SyntaxKind.ArrayExpression:
       return visitNode(cb, (<Types.ArrayExpressionNode>node).elementType);
     case Types.SyntaxKind.DecoratorExpression:

--- a/packages/adl/compiler/scanner.ts
+++ b/packages/adl/compiler/scanner.ts
@@ -478,9 +478,7 @@ export class Scanner {
                 this.next(Kind.BarEquals, 2) :
                 this.next(Kind.Bar);
 
-        case CharacterCodes.singleQuote:
         case CharacterCodes.doubleQuote:
-        case CharacterCodes.backtick:
           return this.scanString();
 
         default:
@@ -821,17 +819,11 @@ export class Scanner {
         case CharacterCodes.t:
           result += '\t';
           break;
-        case CharacterCodes.singleQuote:
-          result += '\'';
-          break;
         case CharacterCodes.doubleQuote:
           result += '"';
           break;
         case CharacterCodes.backslash:
           result += '\\';
-          break;
-        case CharacterCodes.backtick:
-          result += '`';
           break;
         default:
           this.error(messages.InvalidEscapeSequence);

--- a/packages/adl/compiler/scanner.ts
+++ b/packages/adl/compiler/scanner.ts
@@ -121,7 +121,6 @@ export enum Kind {
   ImportKeyword,
   ModelKeyword,
   InterfaceKeyword,
-  AliasKeyword,
   TrueKeyword,
   FalseKeyword
 }
@@ -130,7 +129,6 @@ const keywords = new Map([
   ['import', Kind.ImportKeyword],
   ['model', Kind.ModelKeyword],
   ['interface', Kind.InterfaceKeyword],
-  ['alias', Kind.AliasKeyword],
   ['true', Kind.TrueKeyword],
   ['false', Kind.FalseKeyword]
 ]);

--- a/packages/adl/compiler/types.ts
+++ b/packages/adl/compiler/types.ts
@@ -122,7 +122,6 @@ export enum SyntaxKind {
   StringLiteral,
   NumericLiteral,
   BooleanLiteral,
-  AliasStatement,
   TemplateApplication,
   TemplateParameterDeclaration
 }
@@ -142,8 +141,7 @@ export interface ADLScriptNode extends Node {
 export type Statement =
   | ImportStatementNode
   | ModelStatementNode
-  | InterfaceStatementNode
-  | AliasStatementNode;
+  | InterfaceStatementNode;
 
 export interface ImportStatementNode extends Node {
   kind: SyntaxKind.ImportStatement;
@@ -269,12 +267,6 @@ export interface UnionExpressionNode extends Node {
 export interface IntersectionExpressionNode extends Node {
   kind: SyntaxKind.IntersectionExpression;
   options: Array<Expression>;
-}
-
-export interface AliasStatementNode extends Node {
-  kind: SyntaxKind.AliasStatement;
-  id: IdentifierNode;
-  target: Expression;
 }
 
 export interface TemplateApplicationNode extends Node {

--- a/packages/adl/language.grammar
+++ b/packages/adl/language.grammar
@@ -266,7 +266,6 @@ DecoratorList :
 
 Decorator :
     `@` MemberExpression DecoratorArguments?
-    `[` MemberExpression DecoratorArguments? `]`
 
 DecoratorArguments :
    Literal

--- a/packages/adl/language.grammar
+++ b/packages/adl/language.grammar
@@ -25,7 +25,6 @@ Keyword :
     `import`
     `model`
     `interface`
-    `alias`
 
 Identifier :
     IdentifierName but not Keyword
@@ -182,7 +181,6 @@ StatementList :
 
 Statement :
     ImportStatement
-    AliasStatement
     ModelStatement
     InterfaceStatement
 
@@ -193,9 +191,6 @@ ImportStatement :
 NamedImports : 
     Identifier
     NamedImports `,` Identifier
-
-AliasStatement :
-    `alias` Identifier `:` Expression `;`
 
 ModelStatement :
     DecoratorList? `model` Identifier `{` ModelBody? `}`

--- a/packages/adl/language.grammar
+++ b/packages/adl/language.grammar
@@ -95,36 +95,20 @@ BinaryDigits :
 BinaryDigit :
     one of `0` `1`
 
-StringLiteral :
-    `'` SingleStringCharacters? `'`
-    `"` DoubleStringCharacters? `"`
-    ``` BacktickStringCharacters? ```
-
 // TODO: triple-quoted strings not specified yet, tricky to express.
 
-SingleStringCharacters :
-   SingleStringCharacter SingleStringCharacters?
+StringLiteral :
+    `"` StringCharacters? `"`
 
-SingleStringCharacter :
-    SourceCharacter but not one of `'` or `\`
-    `\` EscapeCharacter
+StringCharacters :
+   StringCharacter StringCharacters?
 
-DoubleStringCharacters :
-   SingleStringCharacter SingleStringCharacters?
-
-DoubleStringCharacter :
+StringCharacter :
     SourceCharacter but not one of `"` or `\`
     `\` EscapeCharacter
 
-BacktickStringCharacters :
-   SingleStringCharacter SingleStringCharacters?
-
-BacktickStringCharacter :
-    SourceCharacter but not one of ``` or `\`
-    `\` EscapeCharacter
-
 EscapeCharacter :
-    one of `'` `"` ``` `r` `n` `t` `\`
+    one of `"` `r` `n` `t` `\`
 
 Punctuator : 
     one of  `|` `:` `,` `;` `.` `<` `>` `(` `)` `{` `}` `[` `]` `@` `...`

--- a/packages/adl/language.grammar
+++ b/packages/adl/language.grammar
@@ -55,7 +55,6 @@ NumericLiteral :
 
 DecimalLiteral :
     DecimalIntegerLiteral `.` DecimalDigits? ExponentPart?
-    `.` DecimalDigits ExponentPart?
     DecimalIntegerLiteral ExponentPart?
 
 DecimalIntegerLiteral :
@@ -69,10 +68,7 @@ DecimalDigit :
     one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 
 ExponentPart :
-    ExponentIndicator SignedInteger
-
-ExponentIndicator : 
-    one of `e` `E`
+    `e` SignedInteger
 
 SignedInteger :
     DecimalDigits
@@ -81,7 +77,6 @@ SignedInteger :
 
 HexIntegerLiteral :
     `0x` HexDigits
-    `0X` HexDigits
 
 HexDigits :
     HexDigit
@@ -89,6 +84,16 @@ HexDigits :
 
 HexDigit : 
     one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `a` `b` `c` `d` `e` `f` `A` `B` `C` `D` `E` `F`
+
+BinaryIntegerLiteral :
+    `0b` BinaryDigits
+
+BinaryDigits :
+    BinaryDigit
+    BinaryDigits BinaryDigit
+
+BinaryDigit :
+    one of `0` `1`
 
 StringLiteral :
     `'` SingleStringCharacters? `'`

--- a/packages/adl/language.md
+++ b/packages/adl/language.md
@@ -90,32 +90,16 @@
 &emsp;&emsp;<a name="BinaryDigit"></a>*BinaryDigit* **:** **one of** `` 0 ``&emsp;`` 1 ``  
   
 &emsp;&emsp;<a name="StringLiteral"></a>*StringLiteral* **:**  
-&emsp;&emsp;&emsp;<a name="StringLiteral-82ecb3d9"></a>`` ' ``&emsp;*[SingleStringCharacters](#SingleStringCharacters)*<sub>opt</sub>&emsp;`` ' ``  
-&emsp;&emsp;&emsp;<a name="StringLiteral-15d8b1f1"></a>`` " ``&emsp;*[DoubleStringCharacters](#DoubleStringCharacters)*<sub>opt</sub>&emsp;`` " ``  
-&emsp;&emsp;&emsp;<a name="StringLiteral-01e5f820"></a>`` ` ``&emsp;*[BacktickStringCharacters](#BacktickStringCharacters)*<sub>opt</sub>&emsp;`` ` ``  
+&emsp;&emsp;&emsp;<a name="StringLiteral-557c08bf"></a>`` " ``&emsp;*[StringCharacters](#StringCharacters)*<sub>opt</sub>&emsp;`` " ``  
   
-&emsp;&emsp;<a name="SingleStringCharacters"></a>*SingleStringCharacters* **:**  
-&emsp;&emsp;&emsp;<a name="SingleStringCharacters-17d28457"></a>*[SingleStringCharacter](#SingleStringCharacter)*&emsp;*[SingleStringCharacters](#SingleStringCharacters)*<sub>opt</sub>  
+&emsp;&emsp;<a name="StringCharacters"></a>*StringCharacters* **:**  
+&emsp;&emsp;&emsp;<a name="StringCharacters-7568b390"></a>*[StringCharacter](#StringCharacter)*&emsp;*[StringCharacters](#StringCharacters)*<sub>opt</sub>  
   
-&emsp;&emsp;<a name="SingleStringCharacter"></a>*SingleStringCharacter* **:**  
-&emsp;&emsp;&emsp;<a name="SingleStringCharacter-20af69b8"></a>*[SourceCharacter](#SourceCharacter)* **but not** **one of** `` ' `` **or** `` \ ``  
-&emsp;&emsp;&emsp;<a name="SingleStringCharacter-3b4c2a4a"></a>`` \ ``&emsp;*[EscapeCharacter](#EscapeCharacter)*  
+&emsp;&emsp;<a name="StringCharacter"></a>*StringCharacter* **:**  
+&emsp;&emsp;&emsp;<a name="StringCharacter-50b66e4c"></a>*[SourceCharacter](#SourceCharacter)* **but not** **one of** `` " `` **or** `` \ ``  
+&emsp;&emsp;&emsp;<a name="StringCharacter-3b4c2a4a"></a>`` \ ``&emsp;*[EscapeCharacter](#EscapeCharacter)*  
   
-&emsp;&emsp;<a name="DoubleStringCharacters"></a>*DoubleStringCharacters* **:**  
-&emsp;&emsp;&emsp;<a name="DoubleStringCharacters-17d28457"></a>*[SingleStringCharacter](#SingleStringCharacter)*&emsp;*[SingleStringCharacters](#SingleStringCharacters)*<sub>opt</sub>  
-  
-&emsp;&emsp;<a name="DoubleStringCharacter"></a>*DoubleStringCharacter* **:**  
-&emsp;&emsp;&emsp;<a name="DoubleStringCharacter-50b66e4c"></a>*[SourceCharacter](#SourceCharacter)* **but not** **one of** `` " `` **or** `` \ ``  
-&emsp;&emsp;&emsp;<a name="DoubleStringCharacter-3b4c2a4a"></a>`` \ ``&emsp;*[EscapeCharacter](#EscapeCharacter)*  
-  
-&emsp;&emsp;<a name="BacktickStringCharacters"></a>*BacktickStringCharacters* **:**  
-&emsp;&emsp;&emsp;<a name="BacktickStringCharacters-17d28457"></a>*[SingleStringCharacter](#SingleStringCharacter)*&emsp;*[SingleStringCharacters](#SingleStringCharacters)*<sub>opt</sub>  
-  
-&emsp;&emsp;<a name="BacktickStringCharacter"></a>*BacktickStringCharacter* **:**  
-&emsp;&emsp;&emsp;<a name="BacktickStringCharacter-4610ad0d"></a>*[SourceCharacter](#SourceCharacter)* **but not** **one of** `` ` `` **or** `` \ ``  
-&emsp;&emsp;&emsp;<a name="BacktickStringCharacter-3b4c2a4a"></a>`` \ ``&emsp;*[EscapeCharacter](#EscapeCharacter)*  
-  
-&emsp;&emsp;<a name="EscapeCharacter"></a>*EscapeCharacter* **:** **one of** `` ' ``&emsp;`` " ``&emsp;`` ` ``&emsp;`` r ``&emsp;`` n ``&emsp;`` t ``&emsp;`` \ ``  
+&emsp;&emsp;<a name="EscapeCharacter"></a>*EscapeCharacter* **:** **one of** `` " ``&emsp;`` r ``&emsp;`` n ``&emsp;`` t ``&emsp;`` \ ``  
   
 &emsp;&emsp;<a name="Punctuator"></a>*Punctuator* **:** **one of** `` | ``&emsp;`` : ``&emsp;`` , ``&emsp;`` ; ``&emsp;`` . ``&emsp;`` < ``&emsp;`` > ``&emsp;`` ( ``&emsp;`` ) ``&emsp;`` { ``&emsp;`` } ``&emsp;`` [ ``&emsp;`` ] ``&emsp;`` @ ``&emsp;`` ... ``  
   

--- a/packages/adl/language.md
+++ b/packages/adl/language.md
@@ -22,7 +22,6 @@
 &emsp;&emsp;&emsp;<a name="Keyword-0330acf5"></a>`` import ``  
 &emsp;&emsp;&emsp;<a name="Keyword-fa60d604"></a>`` model ``  
 &emsp;&emsp;&emsp;<a name="Keyword-ef54526d"></a>`` interface ``  
-&emsp;&emsp;&emsp;<a name="Keyword-921cc095"></a>`` alias ``  
   
 &emsp;&emsp;<a name="Identifier"></a>*Identifier* **:**  
 &emsp;&emsp;&emsp;<a name="Identifier-11758399"></a>*[IdentifierName](#IdentifierName)* **but not** *[Keyword](#Keyword)*  
@@ -168,7 +167,6 @@
   
 &emsp;&emsp;<a name="Statement"></a>*Statement* **:**  
 &emsp;&emsp;&emsp;<a name="Statement-648ff91f"></a>*[ImportStatement](#ImportStatement)*  
-&emsp;&emsp;&emsp;<a name="Statement-0d99421b"></a>*[AliasStatement](#AliasStatement)*  
 &emsp;&emsp;&emsp;<a name="Statement-3606dce2"></a>*[ModelStatement](#ModelStatement)*  
 &emsp;&emsp;&emsp;<a name="Statement-a875a11d"></a>*[InterfaceStatement](#InterfaceStatement)*  
   
@@ -179,9 +177,6 @@
 &emsp;&emsp;<a name="NamedImports"></a>*NamedImports* **:**  
 &emsp;&emsp;&emsp;<a name="NamedImports-06b6ace8"></a>*[Identifier](#Identifier)*  
 &emsp;&emsp;&emsp;<a name="NamedImports-02b3b1dc"></a>*[NamedImports](#NamedImports)*&emsp;`` , ``&emsp;*[Identifier](#Identifier)*  
-  
-&emsp;&emsp;<a name="AliasStatement"></a>*AliasStatement* **:**  
-&emsp;&emsp;&emsp;<a name="AliasStatement-d918b509"></a>`` alias ``&emsp;*[Identifier](#Identifier)*&emsp;`` : ``&emsp;*[Expression](#Expression)*&emsp;`` ; ``  
   
 &emsp;&emsp;<a name="ModelStatement"></a>*ModelStatement* **:**  
 &emsp;&emsp;&emsp;<a name="ModelStatement-b7b1d16b"></a>*[DecoratorList](#DecoratorList)*<sub>opt</sub>&emsp;`` model ``&emsp;*[Identifier](#Identifier)*&emsp;`` { ``&emsp;*[ModelBody](#ModelBody)*<sub>opt</sub>&emsp;`` } ``  

--- a/packages/adl/language.md
+++ b/packages/adl/language.md
@@ -252,7 +252,6 @@
   
 &emsp;&emsp;<a name="Decorator"></a>*Decorator* **:**  
 &emsp;&emsp;&emsp;<a name="Decorator-77540820"></a>`` @ ``&emsp;*[MemberExpression](#MemberExpression)*&emsp;*[DecoratorArguments](#DecoratorArguments)*<sub>opt</sub>  
-&emsp;&emsp;&emsp;<a name="Decorator-bc994750"></a>`` [ ``&emsp;*[MemberExpression](#MemberExpression)*&emsp;*[DecoratorArguments](#DecoratorArguments)*<sub>opt</sub>&emsp;`` ] ``  
   
 &emsp;&emsp;<a name="DecoratorArguments"></a>*DecoratorArguments* **:**  
 &emsp;&emsp;&emsp;<a name="DecoratorArguments-92e97e03"></a>*[Literal](#Literal)*  

--- a/packages/adl/language.md
+++ b/packages/adl/language.md
@@ -52,7 +52,6 @@
   
 &emsp;&emsp;<a name="DecimalLiteral"></a>*DecimalLiteral* **:**  
 &emsp;&emsp;&emsp;<a name="DecimalLiteral-fb5198a6"></a>*[DecimalIntegerLiteral](#DecimalIntegerLiteral)*&emsp;`` . ``&emsp;*[DecimalDigits](#DecimalDigits)*<sub>opt</sub>&emsp;*[ExponentPart](#ExponentPart)*<sub>opt</sub>  
-&emsp;&emsp;&emsp;<a name="DecimalLiteral-5cf3aa35"></a>`` . ``&emsp;*[DecimalDigits](#DecimalDigits)*&emsp;*[ExponentPart](#ExponentPart)*<sub>opt</sub>  
 &emsp;&emsp;&emsp;<a name="DecimalLiteral-13dbaf21"></a>*[DecimalIntegerLiteral](#DecimalIntegerLiteral)*&emsp;*[ExponentPart](#ExponentPart)*<sub>opt</sub>  
   
 &emsp;&emsp;<a name="DecimalIntegerLiteral"></a>*DecimalIntegerLiteral* **:**  
@@ -65,9 +64,7 @@
 &emsp;&emsp;<a name="DecimalDigit"></a>*DecimalDigit* **:** **one of** `` 0 ``&emsp;`` 1 ``&emsp;`` 2 ``&emsp;`` 3 ``&emsp;`` 4 ``&emsp;`` 5 ``&emsp;`` 6 ``&emsp;`` 7 ``&emsp;`` 8 ``&emsp;`` 9 ``  
   
 &emsp;&emsp;<a name="ExponentPart"></a>*ExponentPart* **:**  
-&emsp;&emsp;&emsp;<a name="ExponentPart-7f837518"></a>*[ExponentIndicator](#ExponentIndicator)*&emsp;*[SignedInteger](#SignedInteger)*  
-  
-&emsp;&emsp;<a name="ExponentIndicator"></a>*ExponentIndicator* **:** **one of** `` e ``&emsp;`` E ``  
+&emsp;&emsp;&emsp;<a name="ExponentPart-f88eb2da"></a>`` e ``&emsp;*[SignedInteger](#SignedInteger)*  
   
 &emsp;&emsp;<a name="SignedInteger"></a>*SignedInteger* **:**  
 &emsp;&emsp;&emsp;<a name="SignedInteger-6d7b4e5f"></a>*[DecimalDigits](#DecimalDigits)*  
@@ -76,13 +73,21 @@
   
 &emsp;&emsp;<a name="HexIntegerLiteral"></a>*HexIntegerLiteral* **:**  
 &emsp;&emsp;&emsp;<a name="HexIntegerLiteral-cf154180"></a>`` 0x ``&emsp;*[HexDigits](#HexDigits)*  
-&emsp;&emsp;&emsp;<a name="HexIntegerLiteral-9ef756f3"></a>`` 0X ``&emsp;*[HexDigits](#HexDigits)*  
   
 &emsp;&emsp;<a name="HexDigits"></a>*HexDigits* **:**  
 &emsp;&emsp;&emsp;<a name="HexDigits-a0c48a71"></a>*[HexDigit](#HexDigit)*  
 &emsp;&emsp;&emsp;<a name="HexDigits-c8221899"></a>*[HexDigits](#HexDigits)*&emsp;*[HexDigit](#HexDigit)*  
   
 &emsp;&emsp;<a name="HexDigit"></a>*HexDigit* **:** **one of** `` 0 ``&emsp;`` 1 ``&emsp;`` 2 ``&emsp;`` 3 ``&emsp;`` 4 ``&emsp;`` 5 ``&emsp;`` 6 ``&emsp;`` 7 ``&emsp;`` 8 ``&emsp;`` 9 ``&emsp;`` a ``&emsp;`` b ``&emsp;`` c ``&emsp;`` d ``&emsp;`` e ``&emsp;`` f ``&emsp;`` A ``&emsp;`` B ``&emsp;`` C ``&emsp;`` D ``&emsp;`` E ``&emsp;`` F ``  
+  
+&emsp;&emsp;<a name="BinaryIntegerLiteral"></a>*BinaryIntegerLiteral* **:**  
+&emsp;&emsp;&emsp;<a name="BinaryIntegerLiteral-600d7817"></a>`` 0b ``&emsp;*[BinaryDigits](#BinaryDigits)*  
+  
+&emsp;&emsp;<a name="BinaryDigits"></a>*BinaryDigits* **:**  
+&emsp;&emsp;&emsp;<a name="BinaryDigits-e5f1ee23"></a>*[BinaryDigit](#BinaryDigit)*  
+&emsp;&emsp;&emsp;<a name="BinaryDigits-82aa7443"></a>*[BinaryDigits](#BinaryDigits)*&emsp;*[BinaryDigit](#BinaryDigit)*  
+  
+&emsp;&emsp;<a name="BinaryDigit"></a>*BinaryDigit* **:** **one of** `` 0 ``&emsp;`` 1 ``  
   
 &emsp;&emsp;<a name="StringLiteral"></a>*StringLiteral* **:**  
 &emsp;&emsp;&emsp;<a name="StringLiteral-82ecb3d9"></a>`` ' ``&emsp;*[SingleStringCharacters](#SingleStringCharacters)*<sub>opt</sub>&emsp;`` ' ``  

--- a/packages/adl/samples/appconfig/keys.adl
+++ b/packages/adl/samples/appconfig/keys.adl
@@ -1,4 +1,4 @@
-@resource('/keys')
+@resource("/keys")
 interface KeysResource(
   ... ServiceParams,
   ... SyncTokenHeader

--- a/packages/adl/samples/appconfig/keyvalues.adl
+++ b/packages/adl/samples/appconfig/keyvalues.adl
@@ -16,7 +16,7 @@ model KeyWithFilters {
   @query label?: string;
 }
 
-@resource('/kv')
+@resource("/kv")
 interface KeyValuesResource(
   ... ServiceParams,
   ... SyncTokenHeader

--- a/packages/adl/samples/appconfig/labels.adl
+++ b/packages/adl/samples/appconfig/labels.adl
@@ -1,5 +1,5 @@
 
-@resource('/labels')
+@resource("/labels")
 interface LabelsResource(
   ... ServiceParams,
   ... SyncTokenHeader

--- a/packages/adl/samples/appconfig/locks.adl
+++ b/packages/adl/samples/appconfig/locks.adl
@@ -1,4 +1,4 @@
-@resource('/locks')
+@resource("/locks")
 interface LocksResource(
   ... ServiceParams,
   ... SyncTokenHeader

--- a/packages/adl/samples/appconfig/revisions.adl
+++ b/packages/adl/samples/appconfig/revisions.adl
@@ -1,5 +1,5 @@
 
-@resource('/revisions')
+@resource("/revisions")
 interface RevisionsResource(
   ... ServiceParams,
   ... SyncTokenHeader

--- a/packages/adl/samples/confluent/confluent.adl
+++ b/packages/adl/samples/confluent/confluent.adl
@@ -5,7 +5,7 @@ model Uri = string;
 @format("\\w+@\\w+\\.\\w+")
 model email = string;
 
-@doc('Shorthand for setting length limit.')
+@doc("Shorthand for setting length limit.")
 @minLength(5)
 @maxLength(50)
 model MediumString = string;
@@ -26,15 +26,15 @@ interface Organization {
 @doc("Details of the Confluent organization.")
 model OrganizationProperties {
   @doc("UTC Time when Organization resource was created.")
-  @visibility('read')
+  @visibility("read")
   createdTime: date;
 
   @doc("Id of the Confluent organization.")
-  @visibility('read')
+  @visibility("read")
   organizationId: string;
 
   @doc("Single sign-on url for the Confluent organization.")
-  @visibility('read')
+  @visibility("read")
   ssoUrl: Uri;
 
   @doc("Details of the product offering.")
@@ -62,9 +62,9 @@ model OfferDetail {
   termUnit: ShortString;
   
   @doc("SaaS offer status.")
-  status: 'Started' | 'PendingFulfillmentStart' | 'InProgress' |
-          'Subscribed' | 'Suspended' | 'Reinstated' | 'Succeeded' |
-          'Failed' | 'Unsubscribed' | 'Updating';
+  status: "Started" | "PendingFulfillmentStart" | "InProgress" |
+          "Subscribed" | "Suspended" | "Reinstated" | "Succeeded" |
+          "Failed" | "Unsubscribed" | "Updating";
 }
 
 @doc("Details of the subscriber")

--- a/packages/adl/samples/rpaas/liftr.confluent/confluent.adl
+++ b/packages/adl/samples/rpaas/liftr.confluent/confluent.adl
@@ -9,15 +9,15 @@ model OrganizationProperties
 {
   
   """ UTC Time when Organization resource was created. """
-  @visibility('read') 
+  @visibility("read") 
   createdTime: DateTime;
 
   """ Id of the Confluent organization."""
-  @visibility('read') 
+  @visibility("read") 
   organizationId: string;
 
   """ Single sign-on url for the Confluent organization."""
-  @visibility('read') 
+  @visibility("read") 
   ssoUrl: Uri;
 
   """ Details of the product offering."""
@@ -46,9 +46,9 @@ model OfferDetail
   termUnit: string25;
   
   """ SaaS offer status. """
-  status: 'Started' | 'PendingFulfillmentStart' | 'InProgress' |
-          'Subscribed' | 'Suspended' | 'Reinstated' | 'Succeeded' |
-          'Failed' | 'Unsubscribed' | 'Updating';
+  status: "Started" | "PendingFulfillmentStart" | "InProgress" |
+          "Subscribed" | "Suspended" | "Reinstated" | "Succeeded" |
+          "Failed" | "Unsubscribed" | "Updating";
 }
 
 """ Details of the subscriber """
@@ -73,11 +73,11 @@ model OrganizationKeys
   secondary: SecureString;
 }
 
-@doc('Reusable representation of an email address')
-@format('\w+@\w+\.\w+)
+@doc("Reusable representation of an email address")
+@format("\w+@\w+\.\w+)
 model email: string;
 
-@doc('Shorthand for setting length limit.')
+@doc("Shorthand for setting length limit.")
 @length(50)
 model string50: string;
 

--- a/packages/adl/samples/rpaas/liftr.confluent/confluent.rest.adl
+++ b/packages/adl/samples/rpaas/liftr.confluent/confluent.rest.adl
@@ -1,26 +1,26 @@
 ﻿
-@rest('/subscriptions/{subscription}/resourceGroups/{resourceGroup}/providers/Microsoft.Confluent/organizations/{name}')
+@rest("/subscriptions/{subscription}/resourceGroups/{resourceGroup}/providers/Microsoft.Confluent/organizations/{name}")
 interface Organization 
 {
   @get get(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse<Organization>;
 
-  @slro('/operations', OperationStatus)
+  @slro("/operations", OperationStatus)
   @put createOrUpdate(@path subscription: string, @path resourceGroup: string, @path name: string, Organization) : ArmResponse<Organization>;
   @patch update(@path subscription: string, @path resourceGroup: string, @path name: string, OrganizationUpdate) : ArmResponse<Organization>;
   
-  @slro('/operations', OperationStatus)
+  @slro("/operations", OperationStatus)
   @delete delete(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse;
 
   @post getKeys(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse<OrganizationKeys>;
 }
 
-@rest('/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}')
+@rest("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}")
 interface OrganizationListAll
 {
   @get listAll(@path subscription: string) : Page<OrganizationKeys>;
 }
 
-@rest('/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}')
+@rest("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}")
 interface OrganizationList
 {
   @get listByResourceGroup(@path subscription: string, @path resourceGroup: string) : Page<OrganizationKeys>;
@@ -53,19 +53,19 @@ model ArmResponse<T>
 model OperationStatus
 {
   @header AzureAsyncOperation: Uri;
-  status: 'InProgress' | 'Completed' | 'Cancelled' | 'Failed';
+  status: "InProgress" | "Completed" | "Cancelled" | "Failed";
 }
 
 """ Common properties for all ARM resources. """
 model ArmResource
 {
-  @visibility('read')
+  @visibility("read")
   id: string;
 
-  @visibility('read')
+  @visibility("read")
   name: string; 
 
-  @visibility('read')
+  @visibility("read")
   type: string;   
 }
 
@@ -88,15 +88,15 @@ model OrganizationProperties
 {
   
   """ UTC Time when Organization resource was created. """
-  @visibility('read') 
+  @visibility("read") 
   createdTime: DateTime;
 
   """ Id of the Confluent organization."""
-  @visibility('read') 
+  @visibility("read") 
   organizationId: string;
 
   """ Single sign-on url for the Confluent organization."""
-  @visibility('read') 
+  @visibility("read") 
   ssoUrl: Uri;
 
   """ Details of the product offering."""
@@ -125,9 +125,9 @@ model OfferDetail
   termUnit: string25;
   
   """ SaaS offer status. """
-  status: 'Started' | 'PendingFulfillmentStart' | 'InProgress' |
-          'Subscribed' | 'Suspended' | 'Reinstated' | 'Succeeded' |
-          'Failed' | 'Unsubscribed' | 'Updating';
+  status: "Started" | "PendingFulfillmentStart" | "InProgress" |
+          "Subscribed" | "Suspended" | "Reinstated" | "Succeeded" |
+          "Failed" | "Unsubscribed" | "Updating";
 }
 
 """ Details of the subscriber """
@@ -152,11 +152,11 @@ model OrganizationKeys
   secondary: SecureString;
 }
 
-@doc('Reusable representation of an email address')
-@format('\w+@\w+\.\w+)
+@doc("Reusable representation of an email address")
+@format("\\w+@\\w+\\.\\w+")
 model email: string;
 
-@doc('Shorthand for setting length limit.')
+@doc("Shorthand for setting length limit.")
 @length(50)
 model string50: string;
 

--- a/packages/adl/test/test-parser.ts
+++ b/packages/adl/test/test-parser.ts
@@ -52,12 +52,12 @@ describe('syntax', () => {
        }`,
 
       `
-      [Foo()]
+      @Foo()
       model Car {
-         [Foo.bar(10, "hello")]
+         @Foo.bar(10, "hello")
          prop1: number,
          
-         [Foo.baz(a, b)]
+         @Foo.baz(a, b)
          prop2: string
        };`,
 

--- a/packages/adl/test/test-parser.ts
+++ b/packages/adl/test/test-parser.ts
@@ -155,14 +155,6 @@ describe('syntax', () => {
     ]);
   });
 
-  describe('alias statements', () => {
-    parseEach([
-      'alias MyAlias : SomethingElse;',
-      'alias MyAlias : { constantProperty: 4 };',
-      'alias MyAlias : [ string, number ];'
-    ]);
-  });
-
   describe('multiple statements', () => {
     parseEach([`
       model A { };

--- a/packages/adl/test/test-parser.ts
+++ b/packages/adl/test/test-parser.ts
@@ -48,7 +48,7 @@ describe('syntax', () => {
       // parses as if it were `@foo('prop-1') : number`
       `model Car {
          @foo()
-         'prop-1': number;
+         "prop-1": number;
        }`,
 
       `

--- a/packages/adl/test/test-scanner.ts
+++ b/packages/adl/test/test-scanner.ts
@@ -149,13 +149,13 @@ describe('scanner', () => {
 
   it('scans strings single-line strings with escape sequences', () => {
     scanString(
-      '"Hello world \\r\\n \\t \\\' \\" \\` \\\\ !"',
-      'Hello world \r\n \t \' " ` \\ !');
+      '"Hello world \\r\\n \\t \\" \\\\ !"',
+      'Hello world \r\n \t " \\ !');
   });
 
   it('scans multi-line strings', () => {
     scanString(
-      '`More\r\nthan\r\none\r\nline`',
+      '"More\r\nthan\r\none\r\nline"',
       'More\nthan\none\nline');
   });
 

--- a/packages/adl/test/test-scanner.ts
+++ b/packages/adl/test/test-scanner.ts
@@ -121,6 +121,23 @@ describe('scanner', () => {
     strictEqual(scanner.rescanGreaterThan(), Kind.GreaterThanGreaterThan);
   });
 
+  it('scans numeric literals', () => {
+    const all = tokens('42 0xBEEF 0b1010 1.5e4 314.0e-2 1e+1000');
+    verify(all, [
+      [Kind.NumericLiteral, '42'],
+      [Kind.Whitespace],
+      [Kind.NumericLiteral, '0xBEEF'],
+      [Kind.Whitespace],
+      [Kind.NumericLiteral, '0b1010'],
+      [Kind.Whitespace],
+      [Kind.NumericLiteral, '1.5e4'],
+      [Kind.Whitespace],
+      [Kind.NumericLiteral, '314.0e-2'],
+      [Kind.Whitespace],
+      [Kind.NumericLiteral, '1e+1000'],
+    ]);
+  });
+
   function scanString(text: string, expectedValue: string) {
     const scanner = new Scanner(text);
     scanner.onError = (msg, params) => { throw new Error(format(msg.text, ...params)); };


### PR DESCRIPTION
Some follow up to #245, based on discussion there.

* Remove `alias` statement, preferring `model =`

* Clean up numeric literal handling
  * Document binary literals in grammar
  * Remove tolerance of uppercase 0B, 0X, and E for exponent
  * Remove tolerance of leading decimal point

<p>

* Standardize on only double quotes for string literals

* Remove square bracket alternate decorator syntax