### PR TITLE
Use a more secure authentication approach for publishing npm packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,5 @@ common/temp/**
 package-deps.json
 
 *.vsix
+
+.npmrc

--- a/common/changes/@azure-tools/adl/oops_2021-01-25-22-51.json
+++ b/common/changes/@azure-tools/adl/oops_2021-01-25-22-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/common/config/rush/.npmrc-publish
+++ b/common/config/rush/.npmrc-publish
@@ -1,0 +1,24 @@
+# This config file is very similar to common/config/rush/.npmrc, except that .npmrc-publish
+# is used by the "rush publish" command, as publishing often involves different credentials
+# and registries than other operations.
+#
+# Before invoking the package manager, Rush will copy this file to "common/temp/publish-home/.npmrc"
+# and then temporarily map that folder as the "home directory" for the current user account.
+# This enables the same settings to apply for each project folder that gets published.  The copied file
+# will omit any config lines that reference environment variables that are undefined in that session;
+# this avoids problems that would otherwise result due to a missing variable being replaced by
+# an empty string.
+#
+# * * * SECURITY WARNING * * *
+#
+# It is NOT recommended to store authentication tokens in a text file on a lab machine, because
+# other unrelated processes may be able to read the file.  Also, the file may persist indefinitely,
+# for example if the machine loses power.  A safer practice is to pass the token via an
+# environment variable, which can be referenced from .npmrc using ${} expansion.  For example:
+#
+#   //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
+#
+
+registry=https://registry.npmjs.org/
+always-auth=true
+//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -23,9 +23,8 @@ steps:
   displayName: Test
 
 - script: |
-    echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc
     git config --local user.email "azuresdk@microsoft.com"
     git config --local user.name "Azure SDK Bot"
     git remote set-url --push origin https://azure-sdk:$(azuresdk-github-pat)@github.com/Azure/adl.git
-    node common/scripts/install-run-rush.js publish --apply --publish --target-branch master --set-access-level public
+    NPM_AUTH_TOKEN="$(azure-sdk-npm-token)" node common/scripts/install-run-rush.js publish --apply --publish --target-branch master --set-access-level public
   displayName: Release

--- a/packages/adl/package.json
+++ b/packages/adl/package.json
@@ -33,6 +33,13 @@
   },
   "homepage": "https://github.com/Azure/adl#readme",
   "readme": "https://github.com/Azure/adl/blob/master/readme.md",
+  "files": [
+    "lib/*.adl",
+    "dist/**",
+    "readme.md",
+    "samples",
+    "LICENSE"
+  ],
   "devDependencies": {
     "@types/mocha": "^7.0.2",
     "@types/node": "14.0.27",


### PR DESCRIPTION
Let's try this again without writing out a token to a file...  I'm also constraining the set of files that gets included with the npm package, let me know if I should include anything else!