### PR TITLE
Enable pnpm logging to diagnose publish hang

### DIFF
--- a/common/config/rush/.npmrc-publish
+++ b/common/config/rush/.npmrc-publish
@@ -21,4 +21,5 @@
 
 registry=https://registry.npmjs.org/
 always-auth=true
+loglevel=debug
 //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}


### PR DESCRIPTION
For some reason the npm publishing process via `pnpm` is hanging, adding `loglevel=debug` to `.npmrc` to diagnose it.