### PR TITLE
Adjust lauch.json to command line change, git ignore adl-output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,9 @@ temp
 common/temp/**
 package-deps.json
 
+# Default ADL output
+adl-output/
+
 *.vsix
 
 .npmrc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
       "args": [
         "compile",
         "samples/scratch",
-        "--output-file=dist/scratch.openapi.json"
+        "--output-path=dist/scratch-adl-output"
       ],
       "smartStep": true,
       "sourceMaps": true,


### PR DESCRIPTION
Minor change: make F5 work again in VS Code by default and prevent one-off CLI invocations from tracking the output in git.