### PR TITLE
Add byte and datetime primitives

### DIFF
--- a/common/changes/@azure-tools/adl/add-primitives_2021-01-28-23-07.json
+++ b/common/changes/@azure-tools/adl/add-primitives_2021-01-28-23-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Add byte primitive type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/common/changes/@azure-tools/adl/add-primitives_2021-01-28-23-08.json
+++ b/common/changes/@azure-tools/adl/add-primitives_2021-01-28-23-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Add datetime primitive type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/common/changes/@azure-tools/adl/add-rest-subpaths_2021-01-28-23-21.json
+++ b/common/changes/@azure-tools/adl/add-rest-subpaths_2021-01-28-23-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Add float32 primitive type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/packages/adl/lib/lib.adl
+++ b/packages/adl/lib/lib.adl
@@ -4,6 +4,7 @@
 @intrinsic model string { }
 @intrinsic model float64 { }
 @intrinsic model date { }
+@intrinsic model datetime { }
 @intrinsic model boolean { }
 
 // want to change this to

--- a/packages/adl/lib/lib.adl
+++ b/packages/adl/lib/lib.adl
@@ -1,3 +1,4 @@
+@intrinsic model byte { }
 @intrinsic model int64 { }
 @intrinsic model int32 { }
 @intrinsic model safeint { }

--- a/packages/adl/lib/lib.adl
+++ b/packages/adl/lib/lib.adl
@@ -3,6 +3,7 @@
 @intrinsic model int32 { }
 @intrinsic model safeint { }
 @intrinsic model string { }
+@intrinsic model float32 { }
 @intrinsic model float64 { }
 @intrinsic model date { }
 @intrinsic model datetime { }

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -693,7 +693,9 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
           case 'int64':
             return { type: 'integer', format: 'int64' };
           case 'float64':
-            return { type: 'number' };
+            return { type: 'number', format: 'double' };
+          case 'float32':
+            return { type: 'number', format: 'float' };
           case 'string':
             // Return a string schema augmented by decorators
             return applyStringDecorators(adlType, { type: 'string' });

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -699,6 +699,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
             return { type: 'boolean' };
           case 'date':
             return { type: 'string', format: 'date' };
+          case 'datetime':
+            return { type: 'string', format: 'date-time' };
           case 'Map':
             // We assert on valType because Map types always have a type
             const valType = adlType.ownProperties.get("v");

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -686,6 +686,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         }
 
         switch (adlType.name) {
+          case 'byte':
+            return { type: 'string', format: 'byte' };
           case 'int32':
             return { type: 'integer', format: 'int32' };
           case 'int64':


### PR DESCRIPTION
Adding a couple new primitive types that came up while converting `body-complex.json`.  I'm planning to send some individual PRs in the lead-up to taking the `body-complex` PR out of draft mode.