### PR TITLE
Update rest and openapi libraries to support verb decorator subpaths

### DIFF
--- a/common/changes/@azure-tools/adl/add-rest-subpaths_2021-01-28-23-14.json
+++ b/common/changes/@azure-tools/adl/add-rest-subpaths_2021-01-28-23-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Enable HTTP verb decorators to specify a subpath from the parent resource path",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -10,7 +10,7 @@ import {
   getQueryParamName,
   getResources,
   isBody,
-  getOperationVerb,
+  getOperationRoute,
   HttpVerb
 } from './rest.js';
 
@@ -136,11 +136,16 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       pathSegments.push(name);
     }
 
-    const verb = getOperationVerb(prop) || verbForEndpoint(prop.name);
-    if (verb) {
-      return [verb, pathSegments];
+    const route = getOperationRoute(prop)
+    if (route) {
+      return [route.verb, pathSegments, route.subPath?.replace(/^\//g, '')];
     } else {
-      return ['get', pathSegments, prop.name];
+      const verb = verbForEndpoint(prop.name);
+      if (verb) {
+        return [verb , pathSegments];
+      } else {
+        return ['get', pathSegments, prop.name];
+      }
     }
   }
 

--- a/packages/adl/lib/rest.ts
+++ b/packages/adl/lib/rest.ts
@@ -67,12 +67,17 @@ export function isBody(entity: Type) {
 
 export type HttpVerb = "get" | "put" | "post" | "patch" | "delete";
 
-const operationVerbs = new Map<Type, HttpVerb>();
+interface OperationRoute {
+  verb: HttpVerb;
+  subPath?: string;
+}
 
-function setOperationVerb(entity: Type, verb: HttpVerb) {
+const operationRoutes = new Map<Type, OperationRoute>();
+
+function setOperationRoute(entity: Type, verb: OperationRoute) {
   if (entity.kind === "InterfaceProperty") {
-    if (!operationVerbs.has(entity)) {
-      operationVerbs.set(entity, verb);
+    if (!operationRoutes.has(entity)) {
+      operationRoutes.set(entity, verb);
     } else {
       throw new Error(`HTTP verb already applied to ${entity.name}`);
     }
@@ -81,27 +86,42 @@ function setOperationVerb(entity: Type, verb: HttpVerb) {
   }
 }
 
-export function getOperationVerb(entity: Type): HttpVerb | undefined {
-  return operationVerbs.get(entity);
+export function getOperationRoute(entity: Type): OperationRoute | undefined {
+  return operationRoutes.get(entity);
 }
 
-export function get(program: Program, entity: Type) {
-  setOperationVerb(entity, "get");
+export function get(program: Program, entity: Type, subPath?: string) {
+  setOperationRoute(entity, {
+    verb: "get",
+    subPath
+  });
 }
 
-export function put(program: Program, entity: Type) {
-  setOperationVerb(entity, "put");
+export function put(program: Program, entity: Type, subPath?: string) {
+  setOperationRoute(entity, {
+    verb: "put",
+    subPath
+  });
 }
 
-export function post(program: Program, entity: Type) {
-  setOperationVerb(entity, "post");
+export function post(program: Program, entity: Type, subPath?: string) {
+  setOperationRoute(entity, {
+    verb: "post",
+    subPath
+  });
 }
 
-export function patch(program: Program, entity: Type) {
-  setOperationVerb(entity, "patch");
+export function patch(program: Program, entity: Type, subPath?: string) {
+  setOperationRoute(entity, {
+    verb: "patch",
+    subPath
+  });
 }
 
 // BUG #243: How do we deal with reserved words?
-export function _delete(program: Program, entity: Type) {
-  setOperationVerb(entity, "delete");
+export function _delete(program: Program, entity: Type, subPath?: string) {
+  setOperationRoute(entity, {
+    verb: "delete",
+    subPath
+  });
 }


### PR DESCRIPTION
This change updates our `@verb` decorators for HTTP verbs to allow specifying subpaths for the `@resource` path of the parent interface.  Luckily the mechanism was already in place for this in the `openapi` library so I just needed to add the subpath metadata to the decorator functions and apply it.