### PR TITLE
Add --language parameter for generate command

### DIFF
--- a/common/changes/@azure-tools/adl/parameterize-language_2021-02-02-19-02.json
+++ b/common/changes/@azure-tools/adl/parameterize-language_2021-02-02-19-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Remove hardcoded @autorest/core version",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,12 +1,12 @@
 dependencies:
-  '@rush-temp/adl': 'file:projects/adl.tgz'
+  '@rush-temp/adl': file:projects/adl.tgz
   '@types/mkdirp': 1.0.1
   '@types/mocha': 7.0.2
   '@types/node': 14.0.27
   '@types/yargs': 15.0.12
   '@typescript-eslint/eslint-plugin': 2.28.0_d62df2f848be5291fc9d2809dd11a3fb
   '@typescript-eslint/parser': 2.28.0_eslint@6.8.0+typescript@3.9.7
-  autorest: 3.0.6322
+  autorest: 3.0.6335
   eslint: 6.8.0
   grammarkdown: 3.1.1
   mkdirp: 1.0.4
@@ -14,7 +14,7 @@ dependencies:
   ts-node: 8.10.2_typescript@3.9.7
   typescript: 3.9.7
   yargs: 16.2.0
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.12.11:
     dependencies:
@@ -330,14 +330,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
-  /autorest/3.0.6322:
+  /autorest/3.0.6335:
     dev: false
     engines:
       node: '>=10.13.0'
     hasBin: true
     requiresBuild: true
     resolution:
-      integrity: sha512-q0W5FD8TmxCqpPiD9fXGPbt+DCyf3brGvAAnzoFSngcaBgwy/CfvUVVXbwcHEUYzFive++tpQwM6Q0SFHEfKbQ==
+      integrity: sha512-HPYW5pZpSY/rqtx8oXoKPBStkCfxZC1mkejLT1xyOgOIrD0cO98rBYkKHFAfeK7n2Oy6sQGEV2ej/7csj7sShA==
   /balanced-match/1.0.0:
     dev: false
     resolution:
@@ -500,7 +500,7 @@ packages:
   /debug/3.2.6:
     dependencies:
       ms: 2.1.1
-    deprecated: 'Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)'
+    deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dev: false
     resolution:
       integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1831,7 +1831,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-  'file:projects/adl.tgz':
+  file:projects/adl.tgz:
     dependencies:
       '@types/mkdirp': 1.0.1
       '@types/mocha': 7.0.2
@@ -1839,7 +1839,7 @@ packages:
       '@types/yargs': 15.0.12
       '@typescript-eslint/eslint-plugin': 2.28.0_d62df2f848be5291fc9d2809dd11a3fb
       '@typescript-eslint/parser': 2.28.0_eslint@6.8.0+typescript@3.9.7
-      autorest: 3.0.6322
+      autorest: 3.0.6335
       eslint: 6.8.0
       grammarkdown: 3.1.1
       mkdirp: 1.0.4
@@ -1850,19 +1850,19 @@ packages:
     dev: false
     name: '@rush-temp/adl'
     resolution:
-      integrity: sha512-EHElfoVitL2IOdVB1VRuuPkqsmLP7PQRWoPLKiJK9q5xC7DAKj3Z62+0bR4Ra9sKvt6of3AFsRS+HuB+7grUzg==
-      tarball: 'file:projects/adl.tgz'
+      integrity: sha512-vaClYpRyIBjKhYwRn9iqZsshqHpd8h8J3x6y4uiBeY80XnJoGhggrGOh7idSIZ8EMQYkfdtaitoxsz2l8L7U0w==
+      tarball: file:projects/adl.tgz
     version: 0.0.0
 registry: ''
 specifiers:
-  '@rush-temp/adl': 'file:./projects/adl.tgz'
+  '@rush-temp/adl': file:./projects/adl.tgz
   '@types/mkdirp': ~1.0.1
   '@types/mocha': ^7.0.2
   '@types/node': 14.0.27
   '@types/yargs': ~15.0.12
   '@typescript-eslint/eslint-plugin': 2.28.0
   '@typescript-eslint/parser': 2.28.0
-  autorest: ~3.0.6322
+  autorest: ~3.0.6335
   eslint: 6.8.0
   grammarkdown: ^3.1.1
   mkdirp: ~1.0.4

--- a/packages/adl/compiler/cli.ts
+++ b/packages/adl/compiler/cli.ts
@@ -45,6 +45,11 @@ const args = yargs(process.argv.slice(2))
           type: "boolean",
           describe: "Generate a client library for the ADL definition"
         })
+        .option("language", {
+          type: "string",
+          choices: ["typescript", "csharp", "python"],
+          describe: "The language to use for code generation"
+        })
         .option("output-path", {
           type: "string",
           default: "./adl-output",
@@ -117,10 +122,9 @@ async function main() {
       const autoRestPath = new url.URL(`../../node_modules/.bin/${autoRestBin}`, import.meta.url);
 
       // Execute AutoRest on the output file
-      // TODO: Parameterize client language selection
       const result = spawnSync(url.fileURLToPath(autoRestPath), [
         "--version:3.0.6367",
-        "--typescript",
+        `--${args.language}`,
         `--clear-output-folder=true`,
         `--output-folder=${clientPath}`,
         `--title=AdlClient`,

--- a/packages/adl/compiler/cli.ts
+++ b/packages/adl/compiler/cli.ts
@@ -123,7 +123,6 @@ async function main() {
 
       // Execute AutoRest on the output file
       const result = spawnSync(url.fileURLToPath(autoRestPath), [
-        "--version:3.0.6367",
         `--${args.language}`,
         `--clear-output-folder=true`,
         `--output-folder=${clientPath}`,

--- a/packages/adl/package.json
+++ b/packages/adl/package.json
@@ -56,7 +56,7 @@
     "yargs": "~16.2.0",
     "mkdirp": "~1.0.4",
     "@types/mkdirp": "~1.0.1",
-    "autorest": "~3.0.6322"
+    "autorest": "~3.0.6335"
   },
   "type": "module"
 }


### PR DESCRIPTION
This change adds a new `--language` parameter to `adl generate` so that the user can choose the language for which client (and later server) code gets generated.  Currently I'm allowing the languages `typescript`, `csharp`, and `python`.

Here's an example:

```
adl generate --client --language csharp samples/confluent/
```
