### PR TITLE
Add intrinsic null type, null unions, and emit x-nullable in OpenAPI

### DIFF
--- a/common/changes/@azure-tools/adl/null-type_2021-02-04-22-54.json
+++ b/common/changes/@azure-tools/adl/null-type_2021-02-04-22-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Add null intrinsic type, allow unions with it for x-nullable support in OpenAPI emitter",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/eng/pipelines/pull-request.yml
+++ b/eng/pipelines/pull-request.yml
@@ -31,7 +31,8 @@ steps:
 
     echo ""
     echo "Checking for changed output files..."
-    git diff --exit-code --name-only test/output
+    git add -A
+    git diff --exit-code --cached --name-only test/output
 
     code=$?; if [ $code -ne 0 ]; then
       echo ""
@@ -39,7 +40,7 @@ steps:
       echo "Please run `npm run regen-samples`, evaluate the output, and add it to the PR if the output is expected."
       echo "Here's the diff:"
       echo ""
-      git diff test/output
+      git diff --cached test/output
       exit $code
     fi
   displayName: "Check Compiled Sample Output"

--- a/packages/adl/lib/lib.adl
+++ b/packages/adl/lib/lib.adl
@@ -8,6 +8,7 @@
 @intrinsic model date { }
 @intrinsic model datetime { }
 @intrinsic model boolean { }
+@intrinsic model null { }
 
 // want to change this to
 // model<K, V> = [K, V][];

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -142,7 +142,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     } else {
       const verb = verbForEndpoint(prop.name);
       if (verb) {
-        return [verb , pathSegments];
+        return [verb, pathSegments];
       } else {
         return ['get', pathSegments, prop.name];
       }

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -505,7 +505,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     if (type === 'model') {
       // Model unions can only ever be a model type with 'null'
       if (union.options.length > 2) {
-        throw invalidUnionForOpenAPIV2();
+        throw invalidModelUnionForOpenAPIV2();
       }
 
       const otherType = union.options[1];
@@ -515,7 +515,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         schema["x-nullable"] = true;
         return schema;
       } else {
-        throw invalidUnionForOpenAPIV2();
+        throw invalidModelUnionForOpenAPIV2();
       }
     }
 
@@ -543,6 +543,10 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
 
     function invalidUnionForOpenAPIV2() {
       return new Error("Unions cannot be emitted to OpenAPI v2 unless all options are literals of the same type.");
+    }
+
+    function invalidModelUnionForOpenAPIV2() {
+      return new Error("Unions containing multiple model types cannot be emitted to OpenAPI v2 unless the union is between one model type and 'null'.");
     }
   }
 

--- a/packages/adl/samples/nullable/nullable.adl
+++ b/packages/adl/samples/nullable/nullable.adl
@@ -3,6 +3,8 @@ model HasNullables {
   strOrNull: string | null;
   modelOrNull: AnotherModel | null;
   literalsOrNull: "one" | "two" | null;
+  manyNullsOneString: null | null | string | null;
+  manyNullsSomeValues: null | 42 | null | 100 | null;
   // thisWillFail: AnotherModel | string | null;
 }
 

--- a/packages/adl/samples/nullable/nullable.adl
+++ b/packages/adl/samples/nullable/nullable.adl
@@ -3,6 +3,7 @@ model HasNullables {
   strOrNull: string | null;
   modelOrNull: AnotherModel | null;
   literalsOrNull: "one" | "two" | null;
+  // thisWillFail: AnotherModel | string | null;
 }
 
 @resource("/test")

--- a/packages/adl/samples/nullable/nullable.adl
+++ b/packages/adl/samples/nullable/nullable.adl
@@ -5,9 +5,9 @@ model HasNullables {
   literalsOrNull: "one" | "two" | null;
 }
 
-@resource("test")
+@resource("/test")
 interface NullableMethods {
-  get(@query someParam: string | null, modelOrNull: AnotherModel | null): HasNullables
+  @get read(@query someParam: string | null, modelOrNull: AnotherModel | null): HasNullables
 }
 
 model AnotherModel {

--- a/packages/adl/samples/nullable/nullable.adl
+++ b/packages/adl/samples/nullable/nullable.adl
@@ -1,0 +1,15 @@
+model HasNullables {
+  str: string;
+  strOrNull: string | null;
+  modelOrNull: AnotherModel | null;
+  literalsOrNull: "one" | "two" | null;
+}
+
+@resource("test")
+interface NullableMethods {
+  get(@query someParam: string | null, modelOrNull: AnotherModel | null): HasNullables
+}
+
+model AnotherModel {
+  num: int32;
+}

--- a/packages/adl/scripts/regen-samples.js
+++ b/packages/adl/scripts/regen-samples.js
@@ -10,7 +10,8 @@ import { spawnSync, fork } from "child_process";
 // Get this from samples/ directory listing when reliable
 const sampleFolders = [
   "petstore",
-  "confluent"
+  "confluent",
+  "nullable"
 ];
 
 function resolvePath(...parts) {

--- a/packages/adl/test/output/nullable/openapi.json
+++ b/packages/adl/test/output/nullable/openapi.json
@@ -1,0 +1,104 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "(title)",
+    "version": "0000-00-00"
+  },
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "NullableMethods_read",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "someParam",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-nullable": true
+          },
+          {
+            "name": "modelOrNull",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "num": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "required": [
+                "num"
+              ],
+              "x-nullable": true,
+              "x-adl-name": "AnotherModel | null"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/HasNullables"
+            },
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "HasNullables": {
+      "type": "object",
+      "properties": {
+        "str": {
+          "type": "string"
+        },
+        "strOrNull": {
+          "type": "string",
+          "x-nullable": true,
+          "x-adl-name": "string | null"
+        },
+        "modelOrNull": {
+          "type": "object",
+          "properties": {
+            "num": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "required": [
+            "num"
+          ],
+          "x-nullable": true,
+          "x-adl-name": "AnotherModel | null"
+        },
+        "literalsOrNull": {
+          "type": "string",
+          "enum": [
+            "one",
+            "two"
+          ],
+          "x-nullable": true,
+          "x-adl-name": "one | two | null"
+        }
+      },
+      "required": [
+        "str",
+        "strOrNull",
+        "modelOrNull",
+        "literalsOrNull"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/packages/adl/test/output/nullable/openapi.json
+++ b/packages/adl/test/output/nullable/openapi.json
@@ -90,13 +90,29 @@
           ],
           "x-nullable": true,
           "x-adl-name": "one | two | null"
+        },
+        "manyNullsOneString": {
+          "type": "string",
+          "x-nullable": true,
+          "x-adl-name": "null | null | string | null"
+        },
+        "manyNullsSomeValues": {
+          "type": "number",
+          "enum": [
+            42,
+            100
+          ],
+          "x-nullable": true,
+          "x-adl-name": "null | 42 | null | 100 | null"
         }
       },
       "required": [
         "str",
         "strOrNull",
         "modelOrNull",
-        "literalsOrNull"
+        "literalsOrNull",
+        "manyNullsOneString",
+        "manyNullsSomeValues"
       ]
     }
   },


### PR DESCRIPTION
This change introduces an intrinisic `null` model type defined in `lib.adl` which is treated specially by the OpenAPI emitter.  I also expanded our union handling so that when a model type is encountered, we support unions with a single `null` type.  I don't believe we can deal with `oneOf` at all in Swagger, so I'm not allowing union types with arbitrary model types.

Note that I didn't add a `NullKeyword` or any type of parser-level support for the null type or value.  I did try to add this but found that the parser and checker don't have a way to deal with a literal type with the same symbol as its type (`null` and `null`).  I found that the current approach was more straightforward to get `null` support off the ground but I can go add more language-level support if you think it's necessary!
