### PR TITLE
Add script and PR step to check sample output for regressions

### DIFF
--- a/common/changes/@azure-tools/adl/regression-check_2021-02-04-23-10.json
+++ b/common/changes/@azure-tools/adl/regression-check_2021-02-04-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/eng/pipelines/pull-request.yml
+++ b/eng/pipelines/pull-request.yml
@@ -27,6 +27,25 @@ steps:
 
 - script: |
     cd packages/adl
+    npm run regen-samples
+
+    echo ""
+    echo "Checking for changed output files..."
+    git diff --exit-code --name-only test/output
+
+    code=$?; if [ $code -ne 0 ]; then
+      echo ""
+      echo "Files under test/output/ have changed!"
+      echo "Please run `npm run regen-samples`, evaluate the output, and add it to the PR if the output is expected."
+      echo "Here's the diff:"
+      echo ""
+      git diff test/output
+      exit $code
+    fi
+  displayName: "Check Compiled Sample Output"
+
+- script: |
+    cd packages/adl
     npm link
     npx adl generate samples/confluent/ --client
   displayName: "Sanity Check Client Generation"

--- a/packages/adl/package.json
+++ b/packages/adl/package.json
@@ -16,7 +16,8 @@
     "watch": "tsc -p . --watch",
     "prepare": "npm run build",
     "test": "mocha 'dist/test/**/*.js'",
-    "grammargen": "grammarkdown --newLine LF language.grammar"
+    "grammargen": "grammarkdown --newLine LF language.grammar",
+    "regen-samples": "node scripts/regen-samples.js"
   },
   "repository": {
     "type": "git",

--- a/packages/adl/scripts/regen-samples.js
+++ b/packages/adl/scripts/regen-samples.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+// NOTE: For now, this script assumes it is being run from
+//       the repo path packages/adl/.
+
+import url from "url";
+import mkdirp from "mkdirp";
+import { spawnSync, fork } from "child_process";
+
+// Get this from samples/ directory listing when reliable
+const sampleFolders = [
+  "petstore",
+  "confluent"
+];
+
+function resolvePath(...parts) {
+  const resolvedPath = new url.URL(parts.join(''), import.meta.url);
+  return url.fileURLToPath(resolvedPath);
+}
+
+async function runCompilerAsync(inputPath, outputPath) {
+  return new Promise((resolve, reject) => {
+    const cliProcess = fork("../dist/compiler/cli.js", ["compile", inputPath, `--output-path=${outputPath}`]);
+
+    cliProcess.on('close', (code) => {
+      console.log("process exit", code);
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${cliProcess.stderr}`));
+      }
+    });
+  })
+}
+
+for (const folderName of sampleFolders) {
+  const inputPath = `samples/${folderName}`
+  const outputPath = resolvePath("../test/output/", folderName);
+  mkdirp(outputPath);
+
+  console.log(`\nExecuting \`adl compile ${inputPath}\``)
+  spawnSync(process.execPath, [
+    "dist/compiler/cli.js",
+    "compile",
+    inputPath,
+    `--output-path=${outputPath}`
+  ], {
+    stdio: ['inherit', 'pipe', 'inherit']
+  });
+}

--- a/packages/adl/test/output/confluent/openapi.json
+++ b/packages/adl/test/output/confluent/openapi.json
@@ -1,0 +1,553 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "(title)",
+    "version": "0000-00-00"
+  },
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Confluent/organizations/{name}": {
+      "get": {
+        "operationId": "Organization_get",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroup",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/OrganizationResource"
+            },
+            "description": "Typed response envelope for ARM operations.",
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string"
+              },
+              "x-ms-correlation-request-id": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Organization_createOrUpdate",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroup",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OrganizationResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/OrganizationResource"
+            },
+            "description": "Typed response envelope for ARM operations.",
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string"
+              },
+              "x-ms-correlation-request-id": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Organization_update",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroup",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OrganizationResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/OrganizationResource"
+            },
+            "description": "Typed response envelope for ARM operations.",
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string"
+              },
+              "x-ms-correlation-request-id": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Organization_delete",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroup",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {},
+              "description": "Response envelope for ARM operations.",
+              "x-adl-name": "{}"
+            },
+            "description": "Typed response envelope for ARM operations.",
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string"
+              },
+              "x-ms-correlation-request-id": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Organization_getKeys",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroup",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/OrganizationKeys"
+            },
+            "description": "Typed response envelope for ARM operations.",
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string"
+              },
+              "x-ms-correlation-request-id": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Confluent/organizations": {
+      "get": {
+        "operationId": "OrganizationListAll_listAll",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/OrganizationResource"
+                  },
+                  "x-adl-name": "OrganizationResource[]"
+                },
+                "nextLink": {
+                  "type": "string"
+                }
+              },
+              "description": "Paged response",
+              "required": [
+                "value",
+                "nextLink"
+              ],
+              "x-adl-name": "Page<OrganizationResource>"
+            },
+            "description": "Paged response",
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string"
+              },
+              "x-ms-correlation-request-id": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Confluent/organizations": {
+      "get": {
+        "operationId": "OrganizationList_listByResourceGroup",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroup",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/OrganizationResource"
+                  },
+                  "x-adl-name": "OrganizationResource[]"
+                },
+                "nextLink": {
+                  "type": "string"
+                }
+              },
+              "description": "Paged response",
+              "required": [
+                "value",
+                "nextLink"
+              ],
+              "x-adl-name": "Page<OrganizationResource>"
+            },
+            "description": "Paged response",
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string"
+              },
+              "x-ms-correlation-request-id": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "OrganizationResource": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/OrganizationProperties"
+        }
+      },
+      "required": [
+        "location",
+        "properties"
+      ],
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "description": "Common properties for all ARM resources.",
+          "required": [
+            "id",
+            "name",
+            "type"
+          ],
+          "x-adl-name": "ArmResource<OrganizationProperties>"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "OrganizationKeys": {
+      "type": "object",
+      "properties": {
+        "primary": {
+          "type": "string",
+          "format": "password",
+          "description": "The primary key."
+        },
+        "secondary": {
+          "type": "string",
+          "format": "password",
+          "description": "The secondary Key."
+        }
+      },
+      "required": [
+        "primary",
+        "secondary"
+      ]
+    },
+    "OrganizationProperties": {
+      "type": "object",
+      "properties": {
+        "createdTime": {
+          "type": "string",
+          "format": "date",
+          "description": "UTC Time when Organization resource was created."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Id of the Confluent organization."
+        },
+        "ssoUrl": {
+          "type": "string",
+          "description": "Single sign-on url for the Confluent organization."
+        },
+        "offerDetail": {
+          "$ref": "#/definitions/OfferDetail"
+        },
+        "userDetail": {
+          "$ref": "#/definitions/UserDetail"
+        }
+      },
+      "description": "Details of the Confluent organization.",
+      "required": [
+        "createdTime",
+        "organizationId",
+        "ssoUrl",
+        "offerDetail",
+        "userDetail"
+      ]
+    },
+    "OfferDetail": {
+      "type": "object",
+      "properties": {
+        "publisherId": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 50,
+          "description": "Id of the product publisher."
+        },
+        "id": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 50,
+          "description": "Id of the product offering."
+        },
+        "planId": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 50,
+          "description": "Id of the product offer plan."
+        },
+        "planName": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 50,
+          "description": "Name of the product offer plan."
+        },
+        "termUnit": {
+          "type": "string",
+          "maxLength": 25,
+          "description": "Offer plan term unit."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "Started",
+            "PendingFulfillmentStart",
+            "InProgress",
+            "Subscribed",
+            "Suspended",
+            "Reinstated",
+            "Succeeded",
+            "Failed",
+            "Unsubscribed",
+            "Updating"
+          ],
+          "x-adl-name": "Started | PendingFulfillmentStart | InProgress | Subscribed | Suspended | Reinstated | Succeeded | Failed | Unsubscribed | Updating",
+          "description": "SaaS offer status."
+        }
+      },
+      "description": "Details of the product offering.",
+      "required": [
+        "publisherId",
+        "id",
+        "planId",
+        "planName",
+        "termUnit",
+        "status"
+      ]
+    },
+    "UserDetail": {
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 50,
+          "description": "Subscriber first name."
+        },
+        "lastName": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 50,
+          "description": "Subscriber last name."
+        },
+        "emailAddress": {
+          "type": "string",
+          "pattern": "\\w+@\\w+\\.\\w+",
+          "description": "Subscriber email address."
+        }
+      },
+      "description": "Details of the subscriber",
+      "required": [
+        "firstName",
+        "lastName",
+        "emailAddress"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/packages/adl/test/output/petstore/openapi.json
+++ b/packages/adl/test/output/petstore/openapi.json
@@ -1,0 +1,281 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "(title)",
+    "version": "0000-00-00"
+  },
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/pets/{petId}": {
+      "delete": {
+        "operationId": "Pets_delete",
+        "summary": "Delete a pet.",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/PetId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {},
+              "x-adl-name": "{}"
+            },
+            "description": "Success"
+          },
+          "default": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Error"
+          }
+        }
+      },
+      "get": {
+        "operationId": "Pets_read",
+        "summary": "Returns a pet. Supports eTags.",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/PetId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            },
+            "description": "Success"
+          },
+          "304": {
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            },
+            "description": "Not modified"
+          },
+          "default": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Error"
+          }
+        }
+      }
+    },
+    "/pets": {
+      "get": {
+        "operationId": "Pets_list",
+        "summary": "<blink>List pets.</blink>",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "nextLink",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Pet"
+                  },
+                  "x-adl-name": "Pet[]"
+                },
+                "nextLink": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "items",
+                "nextLink"
+              ],
+              "x-adl-name": "ResponsePage<Pet>"
+            },
+            "description": "Success"
+          },
+          "default": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Error"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      },
+      "post": {
+        "operationId": "Pets_create",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            },
+            "description": "Success"
+          },
+          "default": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Error"
+          }
+        }
+      }
+    },
+    "/pets/{petId}/toys": {
+      "get": {
+        "operationId": "ListPetToysResponse_list",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "nameFilter",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Toy"
+                  },
+                  "x-adl-name": "Toy[]"
+                },
+                "nextLink": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "items",
+                "nextLink"
+              ],
+              "x-adl-name": "ResponsePage<Toy>"
+            },
+            "description": "Success"
+          },
+          "default": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Error"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "description": "Error",
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "Pet": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "Toy": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "petId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "petId",
+        "name"
+      ]
+    }
+  },
+  "parameters": {
+    "PetId": {
+      "name": "petId",
+      "in": "path",
+      "required": true,
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}


### PR DESCRIPTION
I harvested this script and CI check frm #266 since we need it sooner rather than later.  Basically, it checks the Swagger emitter output for a specific list of sample folders to see if there are any changes in output compared to a checked-in set of output files.

When we make any changes that affect emitter output, we'll need to run `npm regen-samples` and check in the output files if we're satisfied with the changes that we see.