### PR TITLE
Add standard HTTP response types to rest.adl

### DIFF
--- a/common/changes/@azure-tools/adl/standard-ok-type_2021-02-05-00-05.json
+++ b/common/changes/@azure-tools/adl/standard-ok-type_2021-02-05-00-05.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@azure-tools/adl",
-      "comment": "Add standard Ok<T> type for success responses in rest.adl",
+      "comment": "Add response model types for many standard HTTP responses in rest.adl",
       "type": "minor"
     }
   ],

--- a/common/changes/@azure-tools/adl/standard-ok-type_2021-02-05-00-05.json
+++ b/common/changes/@azure-tools/adl/standard-ok-type_2021-02-05-00-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Add standard Ok<T> type for success responses in rest.adl",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/common/changes/@azure-tools/adl/standard-ok-type_2021-02-08-18-12.json
+++ b/common/changes/@azure-tools/adl/standard-ok-type_2021-02-08-18-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Renamed Ok<T> to OkResponse<T>",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -253,7 +253,9 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     };
 
     const desc = getDoc(responseModel);
-    response.description = desc ?? "";
+    if (desc) {
+      response.description = desc;
+    }
 
     if (responseModel.kind === 'Model') {
       for (const prop of responseModel.properties.values()) {

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -632,7 +632,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
    *
    * This ensures we use the best name in OpenAPI when the ADL pattern of adding
    * headers and status codes is done by instantiating a template. For example,
-   * given `Ok<T> { @header statusCode: 200; ... T }`, then T is the schema
+   * given `OkResponse<T> { @header statusCode: 200; ... T }`, then T is the schema
    * type.
    */
   function getTypeForSchemaProperties(type: ModelType): ModelType {

--- a/packages/adl/lib/rest.adl
+++ b/packages/adl/lib/rest.adl
@@ -2,3 +2,32 @@ model Ok<T> {
   @header statusCode: 200;
   ... T;
 }
+
+model Created {
+  @header statusCode: 201;
+}
+
+model Accepted {
+  @header statusCode: 202;
+}
+
+model Moved {
+  @header statusCode: 301;
+  @header location: string;
+}
+
+model NotModified {
+  @header statusCode: 304;
+}
+
+model Unauthorized {
+  @header statusCode: 401;
+}
+
+model NotFound {
+  @header statusCode: 404;
+}
+
+model Conflict {
+  @header statusCode: 409;
+}

--- a/packages/adl/lib/rest.adl
+++ b/packages/adl/lib/rest.adl
@@ -3,8 +3,9 @@ model Ok<T> {
   ... T;
 }
 
-model Created {
+model Created<T> {
   @header statusCode: 201;
+  ... T;
 }
 
 model Accepted {

--- a/packages/adl/lib/rest.adl
+++ b/packages/adl/lib/rest.adl
@@ -1,34 +1,37 @@
-model Ok<T> {
+model OkResponse<T> {
   @header statusCode: 200;
   ... T;
 }
 
-model Created<T> {
-  @header statusCode: 201;
-  ... T;
-}
-
-model Accepted {
-  @header statusCode: 202;
-}
-
-model Moved {
-  @header statusCode: 301;
+model LocationHeader {
   @header location: string;
 }
 
-model NotModified {
+model CreatedResponse {
+  @header statusCode: 201;
+}
+
+model AcceptedResponse {
+  @header statusCode: 202;
+}
+
+model MovedResponse {
+  @header statusCode: 301;
+  ... LocationHeader;
+}
+
+model NotModifiedResponse {
   @header statusCode: 304;
 }
 
-model Unauthorized {
+model UnauthorizedResponse {
   @header statusCode: 401;
 }
 
-model NotFound {
+model NotFoundResponse {
   @header statusCode: 404;
 }
 
-model Conflict {
+model ConflictResponse {
   @header statusCode: 409;
 }

--- a/packages/adl/lib/rest.adl
+++ b/packages/adl/lib/rest.adl
@@ -1,4 +1,3 @@
-@doc "Success"
 model Ok<T> {
   @header statusCode: 200;
   ... T;

--- a/packages/adl/lib/rest.adl
+++ b/packages/adl/lib/rest.adl
@@ -1,0 +1,5 @@
+@doc "Success"
+model Ok<T> {
+  @header statusCode: 200;
+  ... T;
+}

--- a/packages/adl/samples/appconfig/keys.adl
+++ b/packages/adl/samples/appconfig/keys.adl
@@ -11,7 +11,7 @@ interface KeysResource(
 
     @query name: string,
     @header after: string,
-  ): Ok<SyncTokenHeader & KeyPage> | Error,
+  ): OkResponse<SyncTokenHeader & KeyPage> | Error,
 
   @doc("Requests the headers and status of the given resource.")
   @operationId("CheckKeys")
@@ -20,5 +20,5 @@ interface KeysResource(
 
     @query name: string,
     @header after: string,
-  ): Ok<SyncTokenHeader> | Error
+  ): OkResponse<SyncTokenHeader> | Error
 }

--- a/packages/adl/samples/appconfig/keyvalues.adl
+++ b/packages/adl/samples/appconfig/keyvalues.adl
@@ -34,7 +34,7 @@ interface KeyValuesResource(
     @doc("Used to select what fields are present in the returned resource(s).")
     @query $Select?: KeyField[],
 
-  ): Ok<SyncTokenHeader & Page<KeyValue>> | Error;
+  ): OkResponse<SyncTokenHeader & Page<KeyValue>> | Error;
 
   @doc("Gets a list of key-values.")
   @operationId("CheckKeyValues")
@@ -48,7 +48,7 @@ interface KeyValuesResource(
     @doc("Used to select what fields are present in the returned resource(s).")
     @query $Select?: KeyField[]
 
-  ): Ok<SyncTokenHeader> | Error;
+  ): OkResponse<SyncTokenHeader> | Error;
 
 
   @doc("Gets a single key-value.")
@@ -61,7 +61,7 @@ interface KeyValuesResource(
     @doc("Used to select what fields are present in the returned resource(s).")
     @query $Select?: KeyField[]
 
-  ): Ok<KeyValueHeaders & KeyValue> | Error;
+  ): OkResponse<KeyValueHeaders & KeyValue> | Error;
 
   @doc("Requests the headers and status of the given resource.")
   @operationId("CheckKeyValue")
@@ -69,7 +69,7 @@ interface KeyValuesResource(
     ... ETagHeaders,
     ... AcceptDatetimeHeader,
     ... KeyWithFilters
-  ): Ok<SyncTokenHeader & LastModifiedHeader> | Error;
+  ): OkResponse<SyncTokenHeader & LastModifiedHeader> | Error;
 
   @doc("Creates a key-value.")
   @operationId("PutKeyValue")
@@ -79,7 +79,7 @@ interface KeyValuesResource(
 
     @header contentType: "application/json",
     @body entity: KeyValue,
-  ): Ok<KeyValueHeaders & KeyValue> | Error;
+  ): OkResponse<KeyValueHeaders & KeyValue> | Error;
 
   @doc("Updates a key-value pair")
   @operationId("UpdateKeyValue")
@@ -89,7 +89,7 @@ interface KeyValuesResource(
 
     @header contentType: "application/json-patch+json",
     @body jsonPatch: string[]
-  ): Ok<KeyValueHeaders & KeyValue> | Error;
+  ): OkResponse<KeyValueHeaders & KeyValue> | Error;
 
 
   @doc("Deletes a key-value.")
@@ -97,7 +97,7 @@ interface KeyValuesResource(
   delete(
     ... KeyWithFilters,
     @header ifMatch: string,
-  ): Ok<KeyValueHeaders & KeyValue> | NoContent<{}> | Error;
+  ): OkResponse<KeyValueHeaders & KeyValue> | NoContent<{}> | Error;
 
 }
 

--- a/packages/adl/samples/appconfig/labels.adl
+++ b/packages/adl/samples/appconfig/labels.adl
@@ -12,7 +12,7 @@ interface LabelsResource(
 
     @query name?: string,
     @query after?: string,
-  ): Ok<SyncTokenHeader & LabelPage> | Error;
+  ): OkResponse<SyncTokenHeader & LabelPage> | Error;
 
   @doc("Requests the headers and status of the given resource.")
   @operationId("CheckLabels")
@@ -22,5 +22,5 @@ interface LabelsResource(
     @query name?: string,
     @query after?: string,
     @query $Select?: LabelField[],
-  ): Ok<SyncTokenHeader> | Error;
+  ): OkResponse<SyncTokenHeader> | Error;
 }

--- a/packages/adl/samples/appconfig/locks.adl
+++ b/packages/adl/samples/appconfig/locks.adl
@@ -8,12 +8,12 @@ interface LocksResource(
     @path key: string,
     @query label: string,
     ... ETagHeaders,
-  ): Ok<SyncTokenHeader & KeyValue> | Error;
+  ): OkResponse<SyncTokenHeader & KeyValue> | Error;
 
   @operationId("DeleteLock")
   delete(
     @path key: string,
     @query label: string,
     ... ETagHeaders,
-  ): Ok<SyncTokenHeader & KeyValue> | Error;
+  ): OkResponse<SyncTokenHeader & KeyValue> | Error;
 }

--- a/packages/adl/samples/appconfig/models.adl
+++ b/packages/adl/samples/appconfig/models.adl
@@ -16,7 +16,7 @@ model AcceptDatetimeHeader {
 }
 
 @doc "Success"
-model Ok<T> {
+model OkResponse<T> {
   @header statusCode: 200;
   ... T;
 }

--- a/packages/adl/samples/appconfig/revisions.adl
+++ b/packages/adl/samples/appconfig/revisions.adl
@@ -18,7 +18,7 @@ interface RevisionsResource(
 
     @doc "A filter used to match keys."
     @query key: string,
-  ): Ok<SyncTokenHeader & Page<KeyValue>> | Error;
+  ): OkResponse<SyncTokenHeader & Page<KeyValue>> | Error;
 
   @doc "Requests the headers and status of the given resource."
   @operationId "CheckRevisions"
@@ -27,5 +27,5 @@ interface RevisionsResource(
 
     @query name: string,
     @query after: string,
-  ): Ok<SyncTokenHeader> | Error;
+  ): OkResponse<SyncTokenHeader> | Error;
 }

--- a/packages/adl/samples/petstore/petstore.adl
+++ b/packages/adl/samples/petstore/petstore.adl
@@ -11,14 +11,6 @@ model Toy {
   name: string;
 }
 
-// Response types
-
-@doc "Success"
-model Ok<T> {
-  @header statusCode: 200;
-  ... T;
-}
-
 @doc "Error"
 model Error {
   code: int32;

--- a/packages/adl/samples/petstore/petstore.adl
+++ b/packages/adl/samples/petstore/petstore.adl
@@ -36,20 +36,20 @@ model PetId {
 @resource "/pets"
 interface Pets {
   @doc "Delete a pet."
-  delete(... PetId): Ok<{}> | Error;
+  delete(... PetId): OkResponse<{}> | Error;
 
   @fancyDoc "List pets."
   @list
-  list(@query nextLink?: string): Ok<ResponsePage<Pet>> | Error;
+  list(@query nextLink?: string): OkResponse<ResponsePage<Pet>> | Error;
 
   @doc "Returns a pet. Supports eTags."
-  read(... PetId): Ok<Pet> | NotModified<Pet> | Error;
+  read(... PetId): OkResponse<Pet> | NotModified<Pet> | Error;
 
-  create(@body pet: Pet): Ok<Pet> | Error;
+  create(@body pet: Pet): OkResponse<Pet> | Error;
 }
 
 @resource "/pets/{petId}/toys"
 interface ListPetToysResponse {
   @list
-  list(@path petId: string, @query nameFilter: string): Ok<ResponsePage<Toy>> | Error;
+  list(@path petId: string, @query nameFilter: string): OkResponse<ResponsePage<Toy>> | Error;
 }

--- a/packages/adl/test/output/nullable/openapi.json
+++ b/packages/adl/test/output/nullable/openapi.json
@@ -49,8 +49,7 @@
           "200": {
             "schema": {
               "$ref": "#/definitions/HasNullables"
-            },
-            "description": ""
+            }
           }
         }
       }

--- a/packages/adl/test/output/petstore/openapi.json
+++ b/packages/adl/test/output/petstore/openapi.json
@@ -27,8 +27,7 @@
               "type": "object",
               "properties": {},
               "x-adl-name": "{}"
-            },
-            "description": "Success"
+            }
           },
           "default": {
             "schema": {
@@ -54,8 +53,7 @@
           "200": {
             "schema": {
               "$ref": "#/definitions/Pet"
-            },
-            "description": "Success"
+            }
           },
           "304": {
             "schema": {
@@ -109,8 +107,7 @@
                 "nextLink"
               ],
               "x-adl-name": "ResponsePage<Pet>"
-            },
-            "description": "Success"
+            }
           },
           "default": {
             "schema": {
@@ -145,8 +142,7 @@
           "200": {
             "schema": {
               "$ref": "#/definitions/Pet"
-            },
-            "description": "Success"
+            }
           },
           "default": {
             "schema": {
@@ -199,8 +195,7 @@
                 "nextLink"
               ],
               "x-adl-name": "ResponsePage<Toy>"
-            },
-            "description": "Success"
+            }
           },
           "default": {
             "schema": {


### PR DESCRIPTION
Moving the `Ok<T>` type to be a standard definition in `rest.adl`.  Anything else I should add?