### PR TITLE
Rename 'interface' concept to 'namespace'

### DIFF
--- a/common/changes/@azure-tools/adl/interface-to-namespace_2021-02-08-19-41.json
+++ b/common/changes/@azure-tools/adl/interface-to-namespace_2021-02-08-19-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Replace `interface` syntax with `namespace` and `op` syntax",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/packages/adl/compiler/binder.ts
+++ b/packages/adl/compiler/binder.ts
@@ -1,6 +1,6 @@
 import { visitChildren } from './parser.js';
 import { ADLSourceFile, Program } from './program.js';
-import { InterfaceStatementNode, ModelStatementNode, Node, SyntaxKind, TemplateParameterDeclarationNode } from './types.js';
+import { NamespaceStatementNode, ModelStatementNode, Node, SyntaxKind, TemplateParameterDeclarationNode } from './types.js';
 
 // trying to avoid masking built-in Symbol
 export type Sym = DecoratorSymbol | TypeSymbol;
@@ -61,7 +61,7 @@ export function createBinder(): Binder {
       case SyntaxKind.ModelStatement:
         bindModelStatement(<any>node);
         break;
-      case SyntaxKind.InterfaceStatement:
+      case SyntaxKind.NamespaceStatement:
         bindInterfaceStatement(<any>node);
         break;
       case SyntaxKind.TemplateParameterDeclaration:
@@ -104,7 +104,7 @@ export function createBinder(): Binder {
   }
 
   function bindInterfaceStatement(
-    statement: InterfaceStatementNode
+    statement: NamespaceStatementNode
   ) {
     currentFile.symbols.set(statement.id.sv, {
       kind: 'type',

--- a/packages/adl/compiler/checker.ts
+++ b/packages/adl/compiler/checker.ts
@@ -5,10 +5,10 @@ import {
   BooleanLiteralNode,
   BooleanLiteralType,
   IdentifierNode,
-  InterfacePropertyNode,
-  InterfaceStatementNode,
-  InterfaceType,
-  InterfaceTypeProperty,
+  NamespacePropertyNode,
+  NamespaceStatementNode,
+  Namespace,
+  NamespaceProperty,
   IntersectionExpressionNode,
   LiteralNode,
   LiteralType,
@@ -79,7 +79,7 @@ export function createChecker(program: Program) {
     checkProgram,
     getLiteralType,
     getTypeName,
-    checkInterfaceProperty
+    checkNamespaceProperty
   };
 
   function getTypeForNode(node: Node): Type {
@@ -93,10 +93,10 @@ export function createChecker(program: Program) {
         return checkModel(<ModelStatementNode>node);
       case SyntaxKind.ModelProperty:
         return checkModelProperty(<ModelPropertyNode>node);
-      case SyntaxKind.InterfaceStatement:
-        return checkInterface(<InterfaceStatementNode>node);
-      case SyntaxKind.InterfaceProperty:
-        return checkInterfaceProperty(<InterfacePropertyNode>node);
+      case SyntaxKind.NamespaceStatement:
+        return checkNamespace(<NamespaceStatementNode>node);
+      case SyntaxKind.NamespaceProperty:
+        return checkNamespaceProperty(<NamespacePropertyNode>node);
       case SyntaxKind.Identifier:
         // decorator bindings presently return an empty binding
         return <any>checkIdentifier(<IdentifierNode>node);
@@ -254,9 +254,9 @@ export function createChecker(program: Program) {
     });
   }
 
-  function checkInterface(node: InterfaceStatementNode) {
-    const type: InterfaceType = createType({
-      kind: 'Interface',
+  function checkNamespace(node: NamespaceStatementNode) {
+    const type: Namespace = createType({
+      kind: 'Namespace',
       name: node.id.sv,
       node: node,
       properties: new Map(),
@@ -264,15 +264,15 @@ export function createChecker(program: Program) {
     });
 
     for (const prop of node.properties) {
-      type.properties.set(prop.id.sv, checkInterfaceProperty(prop));
+      type.properties.set(prop.id.sv, checkNamespaceProperty(prop));
     }
 
     return type;
   }
 
-  function checkInterfaceProperty(prop: InterfacePropertyNode): InterfaceTypeProperty {
+  function checkNamespaceProperty(prop: NamespacePropertyNode): NamespaceProperty {
     return createType({
-      kind: 'InterfaceProperty',
+      kind: 'NamespaceProperty',
       name: prop.id.sv,
       node: prop,
       parameters: <ModelType>getTypeForNode(prop.parameters),

--- a/packages/adl/compiler/parser.ts
+++ b/packages/adl/compiler/parser.ts
@@ -109,6 +109,7 @@ export function parse(code: string) {
 
   function parseNamespaceProperty(decorators: Array<Types.DecoratorExpressionNode>): Types.NamespacePropertyNode {
     const pos = tokenPos();
+    parseExpected(Token.OpKeyword);
     const id = parseIdentifier();
     parseExpected(Token.OpenParen);
     const modelPos = tokenPos();

--- a/packages/adl/compiler/parser.ts
+++ b/packages/adl/compiler/parser.ts
@@ -38,7 +38,7 @@ export function parse(code: string) {
           return parseImportStatement();
         case Token.ModelKeyword:
           return parseModelStatement(decorators);
-        case Token.InterfaceKeyword:
+        case Token.NamespaceKeyword:
           return parseInterfaceStatement(decorators);
         case Token.Semicolon:
           if (decorators.length > 0) {
@@ -66,9 +66,9 @@ export function parse(code: string) {
 
   function parseInterfaceStatement(
     decorators: Array<Types.DecoratorExpressionNode>
-  ): Types.InterfaceStatementNode {
+  ): Types.NamespaceStatementNode {
     const pos = tokenPos();
-    parseExpected(Token.InterfaceKeyword);
+    parseExpected(Token.NamespaceKeyword);
     const id = parseIdentifier();
     let parameters: Types.ModelExpressionNode | undefined;
 
@@ -86,20 +86,20 @@ export function parse(code: string) {
 
 
     parseExpected(Token.OpenBrace);
-    const properties: Array<Types.InterfacePropertyNode> = [];
+    const properties: Array<Types.NamespacePropertyNode> = [];
 
     do {
       if (token() == Token.CloseBrace) {
         break;
       }
       const memberDecorators = parseDecoratorList();
-      properties.push(parseInterfaceProperty(memberDecorators));
+      properties.push(parseNamespaceProperty(memberDecorators));
     } while (parseOptional(Token.Comma) || parseOptional(Token.Semicolon));
 
     parseExpected(Token.CloseBrace);
 
     return finishNode({
-      kind: Types.SyntaxKind.InterfaceStatement,
+      kind: Types.SyntaxKind.NamespaceStatement,
       decorators,
       id,
       parameters,
@@ -107,7 +107,7 @@ export function parse(code: string) {
     }, pos);
   }
 
-  function parseInterfaceProperty(decorators: Array<Types.DecoratorExpressionNode>): Types.InterfacePropertyNode {
+  function parseNamespaceProperty(decorators: Array<Types.DecoratorExpressionNode>): Types.NamespacePropertyNode {
     const pos = tokenPos();
     const id = parseIdentifier();
     parseExpected(Token.OpenParen);
@@ -128,7 +128,7 @@ export function parse(code: string) {
     const returnType = parseExpression();
 
     return finishNode({
-      kind: Types.SyntaxKind.InterfaceProperty,
+      kind: Types.SyntaxKind.NamespaceProperty,
       id,
       parameters,
       returnType,
@@ -637,16 +637,16 @@ export function visitChildren<T>(node: Types.Node, cb: NodeCb<T>): T | undefined
     case Types.SyntaxKind.ImportStatement:
       return visitNode(cb, (<Types.ImportStatementNode>node).id) ||
         visitEach(cb, (<Types.ImportStatementNode>node).as);
-    case Types.SyntaxKind.InterfaceProperty:
-      return visitEach(cb, (<Types.InterfacePropertyNode>node).decorators) ||
-        visitNode(cb, (<Types.InterfacePropertyNode>node).id) ||
-        visitNode(cb, (<Types.InterfacePropertyNode>node).parameters) ||
-        visitNode(cb, (<Types.InterfacePropertyNode>node).returnType);
-    case Types.SyntaxKind.InterfaceStatement:
-      return visitEach(cb, (<Types.InterfaceStatementNode> node).decorators) ||
-        visitNode(cb, (<Types.InterfaceStatementNode>node).id) ||
-        visitNode(cb, (<Types.InterfaceStatementNode>node).parameters) ||
-        visitEach(cb, (<Types.InterfaceStatementNode>node).properties);
+    case Types.SyntaxKind.NamespaceProperty:
+      return visitEach(cb, (<Types.NamespacePropertyNode>node).decorators) ||
+        visitNode(cb, (<Types.NamespacePropertyNode>node).id) ||
+        visitNode(cb, (<Types.NamespacePropertyNode>node).parameters) ||
+        visitNode(cb, (<Types.NamespacePropertyNode>node).returnType);
+    case Types.SyntaxKind.NamespaceStatement:
+      return visitEach(cb, (<Types.NamespaceStatementNode> node).decorators) ||
+        visitNode(cb, (<Types.NamespaceStatementNode>node).id) ||
+        visitNode(cb, (<Types.NamespaceStatementNode>node).parameters) ||
+        visitEach(cb, (<Types.NamespaceStatementNode>node).properties);
     case Types.SyntaxKind.IntersectionExpression:
       return visitEach(cb, (<Types.IntersectionExpressionNode>node).options);
     case Types.SyntaxKind.MemberExpression:

--- a/packages/adl/compiler/program.ts
+++ b/packages/adl/compiler/program.ts
@@ -10,7 +10,7 @@ import { resolvePath } from './util.js';
 import {
   ADLScriptNode,
   DecoratorExpressionNode, IdentifierNode,
-  InterfaceType,
+  Namespace,
   LiteralType,
   ModelStatementNode,
   ModelType,
@@ -27,7 +27,7 @@ export interface Program {
   checker?: ReturnType<typeof createChecker>;
   evalAdlScript(adlScript: string, filePath?: string): void;
   onBuild(cb: (program: Program) => void): void;
-  executeInterfaceDecorators(type: InterfaceType): void;
+  executeInterfaceDecorators(type: Namespace): void;
   executeModelDecorators(type: ModelType): void;
   executeDecorators(type: Type): void;
 }
@@ -37,7 +37,7 @@ export interface ADLSourceFile {
   path: string;
   symbols: SymbolTable;
   models: Array<ModelType>;
-  interfaces: Array<InterfaceType>;
+  interfaces: Array<Namespace>;
 }
 
 export async function compile(rootDir: string, options?: CompilerOptions) {
@@ -71,7 +71,7 @@ export async function compile(rootDir: string, options?: CompilerOptions) {
    * does type checking.
    */
 
-  function executeInterfaceDecorators(type: InterfaceType) {
+  function executeInterfaceDecorators(type: Namespace) {
     const stmt = type.node;
 
     for (const dec of stmt.decorators) {

--- a/packages/adl/compiler/scanner.ts
+++ b/packages/adl/compiler/scanner.ts
@@ -49,6 +49,7 @@ export enum Token {
   ImportKeyword,
   ModelKeyword,
   NamespaceKeyword,
+  OpKeyword,
   TrueKeyword,
   FalseKeyword
 }
@@ -57,6 +58,7 @@ const keywords = new Map([
   ['import', Token.ImportKeyword],
   ['model', Token.ModelKeyword],
   ['namespace', Token.NamespaceKeyword],
+  ['op', Token.OpKeyword],
   ['true', Token.TrueKeyword],
   ['false', Token.FalseKeyword]
 ]);

--- a/packages/adl/compiler/scanner.ts
+++ b/packages/adl/compiler/scanner.ts
@@ -48,7 +48,7 @@ export enum Token {
   // Keywords
   ImportKeyword,
   ModelKeyword,
-  InterfaceKeyword,
+  NamespaceKeyword,
   TrueKeyword,
   FalseKeyword
 }
@@ -56,7 +56,7 @@ export enum Token {
 const keywords = new Map([
   ['import', Token.ImportKeyword],
   ['model', Token.ModelKeyword],
-  ['interface', Token.InterfaceKeyword],
+  ['namespace', Token.NamespaceKeyword],
   ['true', Token.TrueKeyword],
   ['false', Token.FalseKeyword]
 ]);

--- a/packages/adl/compiler/types.ts
+++ b/packages/adl/compiler/types.ts
@@ -13,8 +13,8 @@ export type Type =
   | ModelType
   | ModelTypeProperty
   | TemplateParameterType
-  | InterfaceType
-  | InterfaceTypeProperty
+  | Namespace
+  | NamespaceProperty
   | StringLiteralType
   | NumericLiteralType
   | BooleanLiteralType
@@ -41,19 +41,19 @@ export interface ModelTypeProperty {
   optional: boolean;
 }
 
-export interface InterfaceTypeProperty {
-  kind: 'InterfaceProperty';
-  node: InterfacePropertyNode;
+export interface NamespaceProperty {
+  kind: 'NamespaceProperty';
+  node: NamespacePropertyNode;
   name: string;
   parameters?: ModelType;
   returnType: Type;
 }
 
-export interface InterfaceType extends BaseType {
-  kind: 'Interface';
+export interface Namespace extends BaseType {
+  kind: 'Namespace';
   name: string;
-  node: InterfaceStatementNode;
-  properties: Map<string, InterfaceTypeProperty>;
+  node: NamespaceStatementNode;
+  properties: Map<string, NamespaceProperty>;
   parameters?: ModelType;
 }
 
@@ -109,8 +109,8 @@ export enum SyntaxKind {
   NamedImport,
   DecoratorExpression,
   MemberExpression,
-  InterfaceStatement,
-  InterfaceProperty,
+  NamespaceStatement,
+  NamespaceProperty,
   ModelStatement,
   ModelExpression,
   ModelProperty,
@@ -141,7 +141,7 @@ export interface ADLScriptNode extends Node {
 export type Statement =
   | ImportStatementNode
   | ModelStatementNode
-  | InterfaceStatementNode;
+  | NamespaceStatementNode;
 
 export interface ImportStatementNode extends Node {
   kind: SyntaxKind.ImportStatement;
@@ -184,16 +184,16 @@ export interface MemberExpressionNode extends Node {
   base: MemberExpressionNode | IdentifierNode;
 }
 
-export interface InterfaceStatementNode extends Node {
-  kind: SyntaxKind.InterfaceStatement;
+export interface NamespaceStatementNode extends Node {
+  kind: SyntaxKind.NamespaceStatement;
   id: IdentifierNode;
   parameters?: ModelExpressionNode;
-  properties: Array<InterfacePropertyNode>;
+  properties: Array<NamespacePropertyNode>;
   decorators: Array<DecoratorExpressionNode>;
 }
 
-export interface InterfacePropertyNode extends Node {
-  kind: SyntaxKind.InterfaceProperty;
+export interface NamespacePropertyNode extends Node {
+  kind: SyntaxKind.NamespaceProperty;
   id: IdentifierNode;
   parameters: ModelExpressionNode;
   returnType: Expression;

--- a/packages/adl/language.grammar
+++ b/packages/adl/language.grammar
@@ -25,6 +25,7 @@ Keyword :
     `import`
     `model`
     `namespace`
+    `op`
 
 Identifier :
     IdentifierName but not Keyword
@@ -223,7 +224,7 @@ NamespacePropertyList :
     NamespacePropertyList `;` NamespaceProperty
 
 NamespaceProperty :
-    DecoratorList? Identifier `(` ModelPropertyList? `)` `:` Expression
+    DecoratorList? `op` Identifier `(` ModelPropertyList? `)` `:` Expression
 
 Expression :
     UnionExpressionOrHigher

--- a/packages/adl/language.grammar
+++ b/packages/adl/language.grammar
@@ -24,7 +24,7 @@ Keyword :
     BooleanLiteral
     `import`
     `model`
-    `interface`
+    `namespace`
 
 Identifier :
     IdentifierName but not Keyword
@@ -171,7 +171,7 @@ StatementList :
 Statement :
     ImportStatement
     ModelStatement
-    InterfaceStatement
+    NamespaceStatement
     `;`
 
 ImportStatement :
@@ -210,19 +210,19 @@ ModelProperty:
 ModelSpreadProperty :
     `...` Identifier
 
-InterfaceStatement : 
-    DecoratorList? `interface` Identifier `{` InterfaceBody? `}`
+NamespaceStatement: 
+    DecoratorList? `namespace` Identifier `{` NamespaceBody? `}`
 
-InterfaceBody :
-    InterfacePropertyList `,`?
-    InterfacePropertyList `;`?
+NamespaceBody :
+    NamespacePropertyList `,`?
+    NamespacePropertyList `;`?
 
-InterfacePropertyList :
-    InterfaceProperty
-    InterfacePropertyList `,` InterfaceProperty
-    InterfacePropertyList `;` InterfaceProperty
+NamespacePropertyList :
+    NamespaceProperty
+    NamespacePropertyList `,` NamespaceProperty
+    NamespacePropertyList `;` NamespaceProperty
 
-InterfaceProperty :
+NamespaceProperty :
     DecoratorList? Identifier `(` ModelPropertyList? `)` `:` Expression
 
 Expression :

--- a/packages/adl/language.md
+++ b/packages/adl/language.md
@@ -22,6 +22,7 @@
 &emsp;&emsp;&emsp;<a name="Keyword-0330acf5"></a>`` import ``  
 &emsp;&emsp;&emsp;<a name="Keyword-fa60d604"></a>`` model ``  
 &emsp;&emsp;&emsp;<a name="Keyword-94f12ff9"></a>`` namespace ``  
+&emsp;&emsp;&emsp;<a name="Keyword-c93383ad"></a>`` op ``  
   
 &emsp;&emsp;<a name="Identifier"></a>*Identifier* **:**  
 &emsp;&emsp;&emsp;<a name="Identifier-11758399"></a>*[IdentifierName](#IdentifierName)* **but not** *[Keyword](#Keyword)*  
@@ -209,7 +210,7 @@
 &emsp;&emsp;&emsp;<a name="NamespacePropertyList-89234f4f"></a>*[NamespacePropertyList](#NamespacePropertyList)*&emsp;`` ; ``&emsp;*[NamespaceProperty](#NamespaceProperty)*  
   
 &emsp;&emsp;<a name="NamespaceProperty"></a>*NamespaceProperty* **:**  
-&emsp;&emsp;&emsp;<a name="NamespaceProperty-6e1a4442"></a>*[DecoratorList](#DecoratorList)*<sub>opt</sub>&emsp;*[Identifier](#Identifier)*&emsp;`` ( ``&emsp;*[ModelPropertyList](#ModelPropertyList)*<sub>opt</sub>&emsp;`` ) ``&emsp;`` : ``&emsp;*[Expression](#Expression)*  
+&emsp;&emsp;&emsp;<a name="NamespaceProperty-bdb0dff6"></a>*[DecoratorList](#DecoratorList)*<sub>opt</sub>&emsp;`` op ``&emsp;*[Identifier](#Identifier)*&emsp;`` ( ``&emsp;*[ModelPropertyList](#ModelPropertyList)*<sub>opt</sub>&emsp;`` ) ``&emsp;`` : ``&emsp;*[Expression](#Expression)*  
   
 &emsp;&emsp;<a name="Expression"></a>*Expression* **:**  
 &emsp;&emsp;&emsp;<a name="Expression-3936659b"></a>*[UnionExpressionOrHigher](#UnionExpressionOrHigher)*  

--- a/packages/adl/language.md
+++ b/packages/adl/language.md
@@ -21,7 +21,7 @@
 &emsp;&emsp;&emsp;<a name="Keyword-3508e1fd"></a>*[BooleanLiteral](#BooleanLiteral)*  
 &emsp;&emsp;&emsp;<a name="Keyword-0330acf5"></a>`` import ``  
 &emsp;&emsp;&emsp;<a name="Keyword-fa60d604"></a>`` model ``  
-&emsp;&emsp;&emsp;<a name="Keyword-ef54526d"></a>`` interface ``  
+&emsp;&emsp;&emsp;<a name="Keyword-94f12ff9"></a>`` namespace ``  
   
 &emsp;&emsp;<a name="Identifier"></a>*Identifier* **:**  
 &emsp;&emsp;&emsp;<a name="Identifier-11758399"></a>*[IdentifierName](#IdentifierName)* **but not** *[Keyword](#Keyword)*  
@@ -157,7 +157,7 @@
 &emsp;&emsp;<a name="Statement"></a>*Statement* **:**  
 &emsp;&emsp;&emsp;<a name="Statement-648ff91f"></a>*[ImportStatement](#ImportStatement)*  
 &emsp;&emsp;&emsp;<a name="Statement-3606dce2"></a>*[ModelStatement](#ModelStatement)*  
-&emsp;&emsp;&emsp;<a name="Statement-a875a11d"></a>*[InterfaceStatement](#InterfaceStatement)*  
+&emsp;&emsp;&emsp;<a name="Statement-fe52538f"></a>*[NamespaceStatement](#NamespaceStatement)*  
 &emsp;&emsp;&emsp;<a name="Statement-4a0dac03"></a>`` ; ``  
   
 &emsp;&emsp;<a name="ImportStatement"></a>*ImportStatement* **:**  
@@ -196,20 +196,20 @@
 &emsp;&emsp;<a name="ModelSpreadProperty"></a>*ModelSpreadProperty* **:**  
 &emsp;&emsp;&emsp;<a name="ModelSpreadProperty-ba1e81db"></a>`` ... ``&emsp;*[Identifier](#Identifier)*  
   
-&emsp;&emsp;<a name="InterfaceStatement"></a>*InterfaceStatement* **:**  
-&emsp;&emsp;&emsp;<a name="InterfaceStatement-d483a1e3"></a>*[DecoratorList](#DecoratorList)*<sub>opt</sub>&emsp;`` interface ``&emsp;*[Identifier](#Identifier)*&emsp;`` { ``&emsp;*[InterfaceBody](#InterfaceBody)*<sub>opt</sub>&emsp;`` } ``  
+&emsp;&emsp;<a name="NamespaceStatement"></a>*NamespaceStatement* **:**  
+&emsp;&emsp;&emsp;<a name="NamespaceStatement-9652df2c"></a>*[DecoratorList](#DecoratorList)*<sub>opt</sub>&emsp;`` namespace ``&emsp;*[Identifier](#Identifier)*&emsp;`` { ``&emsp;*[NamespaceBody](#NamespaceBody)*<sub>opt</sub>&emsp;`` } ``  
   
-&emsp;&emsp;<a name="InterfaceBody"></a>*InterfaceBody* **:**  
-&emsp;&emsp;&emsp;<a name="InterfaceBody-42db29a8"></a>*[InterfacePropertyList](#InterfacePropertyList)*&emsp;`` , ``<sub>opt</sub>  
-&emsp;&emsp;&emsp;<a name="InterfaceBody-3356a474"></a>*[InterfacePropertyList](#InterfacePropertyList)*&emsp;`` ; ``<sub>opt</sub>  
+&emsp;&emsp;<a name="NamespaceBody"></a>*NamespaceBody* **:**  
+&emsp;&emsp;&emsp;<a name="NamespaceBody-2073a613"></a>*[NamespacePropertyList](#NamespacePropertyList)*&emsp;`` , ``<sub>opt</sub>  
+&emsp;&emsp;&emsp;<a name="NamespaceBody-491851d8"></a>*[NamespacePropertyList](#NamespacePropertyList)*&emsp;`` ; ``<sub>opt</sub>  
   
-&emsp;&emsp;<a name="InterfacePropertyList"></a>*InterfacePropertyList* **:**  
-&emsp;&emsp;&emsp;<a name="InterfacePropertyList-4b6e0e43"></a>*[InterfaceProperty](#InterfaceProperty)*  
-&emsp;&emsp;&emsp;<a name="InterfacePropertyList-7a4ddc85"></a>*[InterfacePropertyList](#InterfacePropertyList)*&emsp;`` , ``&emsp;*[InterfaceProperty](#InterfaceProperty)*  
-&emsp;&emsp;&emsp;<a name="InterfacePropertyList-f364599f"></a>*[InterfacePropertyList](#InterfacePropertyList)*&emsp;`` ; ``&emsp;*[InterfaceProperty](#InterfaceProperty)*  
+&emsp;&emsp;<a name="NamespacePropertyList"></a>*NamespacePropertyList* **:**  
+&emsp;&emsp;&emsp;<a name="NamespacePropertyList-7c41a03c"></a>*[NamespaceProperty](#NamespaceProperty)*  
+&emsp;&emsp;&emsp;<a name="NamespacePropertyList-f06fd699"></a>*[NamespacePropertyList](#NamespacePropertyList)*&emsp;`` , ``&emsp;*[NamespaceProperty](#NamespaceProperty)*  
+&emsp;&emsp;&emsp;<a name="NamespacePropertyList-89234f4f"></a>*[NamespacePropertyList](#NamespacePropertyList)*&emsp;`` ; ``&emsp;*[NamespaceProperty](#NamespaceProperty)*  
   
-&emsp;&emsp;<a name="InterfaceProperty"></a>*InterfaceProperty* **:**  
-&emsp;&emsp;&emsp;<a name="InterfaceProperty-6e1a4442"></a>*[DecoratorList](#DecoratorList)*<sub>opt</sub>&emsp;*[Identifier](#Identifier)*&emsp;`` ( ``&emsp;*[ModelPropertyList](#ModelPropertyList)*<sub>opt</sub>&emsp;`` ) ``&emsp;`` : ``&emsp;*[Expression](#Expression)*  
+&emsp;&emsp;<a name="NamespaceProperty"></a>*NamespaceProperty* **:**  
+&emsp;&emsp;&emsp;<a name="NamespaceProperty-6e1a4442"></a>*[DecoratorList](#DecoratorList)*<sub>opt</sub>&emsp;*[Identifier](#Identifier)*&emsp;`` ( ``&emsp;*[ModelPropertyList](#ModelPropertyList)*<sub>opt</sub>&emsp;`` ) ``&emsp;`` : ``&emsp;*[Expression](#Expression)*  
   
 &emsp;&emsp;<a name="Expression"></a>*Expression* **:**  
 &emsp;&emsp;&emsp;<a name="Expression-3936659b"></a>*[UnionExpressionOrHigher](#UnionExpressionOrHigher)*  

--- a/packages/adl/lib/arm.ts
+++ b/packages/adl/lib/arm.ts
@@ -40,12 +40,12 @@ export function TrackedResource(
 
          @resource("/subscriptions/{subscriptionId}/providers/${resourceRoot}")
          namespace ${target.name}ListAll {
-           @list @get listAll(@path subscriptionId: string): Page<${resourceModelName}>;
+           @list @get op listAll(@path subscriptionId: string): Page<${resourceModelName}>;
          }
 
          @resource("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/${resourceRoot}")
          namespace ${target.name}List {
-           @list @get listByResourceGroup(@path subscriptionId: string, @path resourceGroup: string): Page<${resourceModelName}>;
+           @list @get op listByResourceGroup(@path subscriptionId: string, @path resourceGroup: string): Page<${resourceModelName}>;
          }
       `);
 
@@ -54,10 +54,10 @@ export function TrackedResource(
       const resourceNamespaceNode = parseStatement<NamespaceStatementNode>(
         // TODO: Might need to generate dynamic namespace here!
         `namespace Temp { \
-          @get get(@path subscriptionId: string, @path resourceGroup: string, @path name: string): ArmResponse<${resourceModelName}>; \
-          @put createOrUpdate(@path subscriptionId: string, @path resourceGroup: string, @path name: string, @body resource: ${resourceModelName}) : ArmResponse<${resourceModelName}>; \
-          @patch update(@path subscriptionId: string, @path resourceGroup: string, @path name: string, @body resource: ${resourceModelName}): ArmResponse<${resourceModelName}>; \
-          @_delete delete(@path subscriptionId: string, @path resourceGroup: string, @path name: string): ArmResponse; \
+          @get op get(@path subscriptionId: string, @path resourceGroup: string, @path name: string): ArmResponse<${resourceModelName}>; \
+          @put op createOrUpdate(@path subscriptionId: string, @path resourceGroup: string, @path name: string, @body resource: ${resourceModelName}) : ArmResponse<${resourceModelName}>; \
+          @patch op update(@path subscriptionId: string, @path resourceGroup: string, @path name: string, @body resource: ${resourceModelName}): ArmResponse<${resourceModelName}>; \
+          @_delete op delete(@path subscriptionId: string, @path resourceGroup: string, @path name: string): ArmResponse; \
         }`
       );
 

--- a/packages/adl/lib/decorators.ts
+++ b/packages/adl/lib/decorators.ts
@@ -154,7 +154,7 @@ export function getVisibility(target: Type): string | undefined {
 const listProperties = new Set<Type>();
 
 export function list(program: Program, target: Type) {
-  if (target.kind === "InterfaceProperty" || target.kind === "ModelProperty") {
+  if (target.kind === "NamespaceProperty" || target.kind === "ModelProperty") {
     listProperties.add(target);
   } else {
     throw new Error("The @list decorator can only be applied to interface or model properties.");

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { Program } from '../compiler/program.js';
-import { ArrayType, InterfaceType, InterfaceTypeProperty, ModelType, ModelTypeProperty, Type, UnionType } from '../compiler/types.js';
+import { ArrayType, Namespace, NamespaceProperty, ModelType, ModelTypeProperty, Type, UnionType } from '../compiler/types.js';
 import { getDoc, getFormat, getIntrinsicType, getMaxLength, getMinLength, isSecret, isList, isIntrinsic } from './decorators.js';
 import {
   basePathForResource,
@@ -82,11 +82,11 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
 
   function emitOpenAPI() {
     for (let resource of getResources()) {
-      if (resource.kind !== 'Interface') {
-        throw new Error("Resource goes on interface");
+      if (resource.kind !== 'Namespace') {
+        throw new Error("Resource goes on namespace");
       }
 
-      emitResource(<InterfaceType>resource);
+      emitResource(<Namespace>resource);
     }
     emitReferences();
 
@@ -96,7 +96,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       JSON.stringify(root, null, 2));
   }
 
-  function emitResource(resource: InterfaceType) {
+  function emitResource(resource: Namespace) {
     currentBasePath = basePathForResource(resource);
 
     for (const [name, prop] of resource.properties) {
@@ -104,7 +104,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     }
   }
 
-  function getPathParameters(iface: InterfaceType, prop: InterfaceTypeProperty) {
+  function getPathParameters(iface: Namespace, prop: NamespaceProperty) {
     return [
       ...(iface.parameters?.properties.values() ?? []),
       ...(prop.parameters?.properties.values() ?? []),
@@ -114,7 +114,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   /**
    * Translates endpoint names like `read` to REST verbs like `get`.
    */
-  function pathForEndpoint(prop: InterfaceTypeProperty, pathParams: ModelTypeProperty[], declaredPathParamNames: string[]): [string, string[], string?] {
+  function pathForEndpoint(prop: NamespaceProperty, pathParams: ModelTypeProperty[], declaredPathParamNames: string[]): [string, string[], string?] {
     const paramByName = new Map(pathParams.map((p) => [p.name, p]));
     const pathSegments = [];
 
@@ -168,7 +168,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     return undefined;
   }
 
-  function emitEndpoint(resource: InterfaceType, prop: InterfaceTypeProperty) {
+  function emitEndpoint(resource: Namespace, prop: NamespaceProperty) {
     const declaredPathParamNames =
       currentBasePath?.match(/\{\w+\}/g)?.map((s) => s.slice(1, -1)) ?? [];
     const params = getPathParameters(resource, prop);

--- a/packages/adl/lib/rest.ts
+++ b/packages/adl/lib/rest.ts
@@ -4,7 +4,7 @@ import { Type } from "../compiler/types";
 const basePaths = new Map<Type, string>();
 
 export function resource(program: Program, entity: Type, basePath = '') {
-  if (entity.kind !== 'Interface') return;
+  if (entity.kind !== 'Namespace') return;
   basePaths.set(entity, basePath);
 }
 
@@ -75,7 +75,7 @@ interface OperationRoute {
 const operationRoutes = new Map<Type, OperationRoute>();
 
 function setOperationRoute(entity: Type, verb: OperationRoute) {
-  if (entity.kind === "InterfaceProperty") {
+  if (entity.kind === "NamespaceProperty") {
     if (!operationRoutes.has(entity)) {
       operationRoutes.set(entity, verb);
     } else {

--- a/packages/adl/samples/appconfig/keys.adl
+++ b/packages/adl/samples/appconfig/keys.adl
@@ -1,5 +1,5 @@
 @resource("/keys")
-interface KeysResource(
+namespace KeysResource(
   ... ServiceParams,
   ... SyncTokenHeader
 ) {

--- a/packages/adl/samples/appconfig/keys.adl
+++ b/packages/adl/samples/appconfig/keys.adl
@@ -6,7 +6,7 @@ namespace KeysResource(
 
   @doc("Gets a list of keys.")
   @operationId("GetKeys")
-  list(
+  op list(
     ... AcceptDatetimeHeader,
 
     @query name: string,
@@ -15,7 +15,7 @@ namespace KeysResource(
 
   @doc("Requests the headers and status of the given resource.")
   @operationId("CheckKeys")
-  listHead(
+  op listHead(
     ... AcceptDatetimeHeader,
 
     @query name: string,

--- a/packages/adl/samples/appconfig/keyvalues.adl
+++ b/packages/adl/samples/appconfig/keyvalues.adl
@@ -17,7 +17,7 @@ model KeyWithFilters {
 }
 
 @resource("/kv")
-interface KeyValuesResource(
+namespace KeyValuesResource(
   ... ServiceParams,
   ... SyncTokenHeader
 ) {

--- a/packages/adl/samples/appconfig/keyvalues.adl
+++ b/packages/adl/samples/appconfig/keyvalues.adl
@@ -24,7 +24,7 @@ namespace KeyValuesResource(
 
   @doc("Gets a list of key-values.")
   @operationId("GetKeyValues")
-  list(
+  op list(
     ... AcceptDatetimeHeader,
     ... KeyFilters,
     
@@ -38,7 +38,7 @@ namespace KeyValuesResource(
 
   @doc("Gets a list of key-values.")
   @operationId("CheckKeyValues")
-  listHead(
+  op listHead(
     ... AcceptDatetimeHeader,
     ... KeyFilters,
 
@@ -53,7 +53,7 @@ namespace KeyValuesResource(
 
   @doc("Gets a single key-value.")
   @operationId("GetKeyValue")
-  read(
+  op read(
     ... ETagHeaders,
     ... AcceptDatetimeHeader,
     ... KeyWithFilters,
@@ -65,7 +65,7 @@ namespace KeyValuesResource(
 
   @doc("Requests the headers and status of the given resource.")
   @operationId("CheckKeyValue")
-  readHead(
+  op readHead(
     ... ETagHeaders,
     ... AcceptDatetimeHeader,
     ... KeyWithFilters
@@ -73,7 +73,7 @@ namespace KeyValuesResource(
 
   @doc("Creates a key-value.")
   @operationId("PutKeyValue")
-  createOrUpdate(
+  op createOrUpdate(
     ... ETagHeaders,
     ... KeyWithFilters,
 
@@ -83,7 +83,7 @@ namespace KeyValuesResource(
 
   @doc("Updates a key-value pair")
   @operationId("UpdateKeyValue")
-  createOrUpdate(
+  op createOrUpdate(
     ... ETagHeaders,
     ... KeyWithFilters,
 
@@ -94,7 +94,7 @@ namespace KeyValuesResource(
 
   @doc("Deletes a key-value.")
   @operationId("DeleteKeyValue")
-  delete(
+  op delete(
     ... KeyWithFilters,
     @header ifMatch: string,
   ): OkResponse<KeyValueHeaders & KeyValue> | NoContent<{}> | Error;

--- a/packages/adl/samples/appconfig/labels.adl
+++ b/packages/adl/samples/appconfig/labels.adl
@@ -7,7 +7,7 @@ namespace LabelsResource(
 
   @doc("Gets a list of labels.")
   @operationId("GetLabels")
-  list(
+  op list(
     ... AcceptDatetimeHeader,
 
     @query name?: string,
@@ -16,7 +16,7 @@ namespace LabelsResource(
 
   @doc("Requests the headers and status of the given resource.")
   @operationId("CheckLabels")
-  listHead(
+  op listHead(
     ... AcceptDatetimeHeader,
 
     @query name?: string,

--- a/packages/adl/samples/appconfig/labels.adl
+++ b/packages/adl/samples/appconfig/labels.adl
@@ -1,6 +1,6 @@
 
 @resource("/labels")
-interface LabelsResource(
+namespace LabelsResource(
   ... ServiceParams,
   ... SyncTokenHeader
 ) {

--- a/packages/adl/samples/appconfig/locks.adl
+++ b/packages/adl/samples/appconfig/locks.adl
@@ -4,14 +4,14 @@ namespace LocksResource(
   ... SyncTokenHeader
 ) {
   @operationId("GetLock")
-  read(
+  op read(
     @path key: string,
     @query label: string,
     ... ETagHeaders,
   ): OkResponse<SyncTokenHeader & KeyValue> | Error;
 
   @operationId("DeleteLock")
-  delete(
+  op delete(
     @path key: string,
     @query label: string,
     ... ETagHeaders,

--- a/packages/adl/samples/appconfig/locks.adl
+++ b/packages/adl/samples/appconfig/locks.adl
@@ -1,5 +1,5 @@
 @resource("/locks")
-interface LocksResource(
+namespace LocksResource(
   ... ServiceParams,
   ... SyncTokenHeader
 ) {

--- a/packages/adl/samples/appconfig/models.adl
+++ b/packages/adl/samples/appconfig/models.adl
@@ -15,12 +15,6 @@ model AcceptDatetimeHeader {
   @header acceptDatetime: date;
 }
 
-@doc "Success"
-model OkResponse<T> {
-  @header statusCode: 200;
-  ... T;
-}
-
 model SyncTokenHeader {
   @doc "Used to guarantee real-time consistency between requests."
   @header syncToken?: string;

--- a/packages/adl/samples/appconfig/revisions.adl
+++ b/packages/adl/samples/appconfig/revisions.adl
@@ -7,7 +7,7 @@ namespace RevisionsResource(
 
   @doc "Gets a list of revisions."
   @operationId "GetRevisions"
-  list(
+  op list(
     ... AcceptDatetimeHeader,
 
     @doc "Used to select what fields are present in the returned resource(s)."
@@ -22,7 +22,7 @@ namespace RevisionsResource(
 
   @doc "Requests the headers and status of the given resource."
   @operationId "CheckRevisions"
-  listHead(
+  op listHead(
     ... AcceptDatetimeHeader,
 
     @query name: string,

--- a/packages/adl/samples/appconfig/revisions.adl
+++ b/packages/adl/samples/appconfig/revisions.adl
@@ -1,6 +1,6 @@
 
 @resource("/revisions")
-interface RevisionsResource(
+namespace RevisionsResource(
   ... ServiceParams,
   ... SyncTokenHeader
 ) {

--- a/packages/adl/samples/confluent/confluent.adl
+++ b/packages/adl/samples/confluent/confluent.adl
@@ -20,7 +20,7 @@ model OrganizationKey = string;
 
 @TrackedResource("Microsoft.Confluent/organizations", OrganizationProperties)
 namespace Organization {
-  @post getKeys(@path subscriptionId: string, @path resourceGroup: string, @path name: string) : ArmResponse<OrganizationKeys>;
+  @post op getKeys(@path subscriptionId: string, @path resourceGroup: string, @path name: string) : ArmResponse<OrganizationKeys>;
 }
 
 @doc("Details of the Confluent organization.")

--- a/packages/adl/samples/confluent/confluent.adl
+++ b/packages/adl/samples/confluent/confluent.adl
@@ -19,7 +19,7 @@ model ShortString = string;
 model OrganizationKey = string;
 
 @TrackedResource("Microsoft.Confluent/organizations", OrganizationProperties)
-interface Organization {
+namespace Organization {
   @post getKeys(@path subscriptionId: string, @path resourceGroup: string, @path name: string) : ArmResponse<OrganizationKeys>;
 }
 

--- a/packages/adl/samples/nullable/nullable.adl
+++ b/packages/adl/samples/nullable/nullable.adl
@@ -9,7 +9,7 @@ model HasNullables {
 }
 
 @resource("/test")
-interface NullableMethods {
+namespace NullableMethods {
   @get read(@query someParam: string | null, modelOrNull: AnotherModel | null): HasNullables
 }
 

--- a/packages/adl/samples/nullable/nullable.adl
+++ b/packages/adl/samples/nullable/nullable.adl
@@ -10,7 +10,7 @@ model HasNullables {
 
 @resource("/test")
 namespace NullableMethods {
-  @get read(@query someParam: string | null, modelOrNull: AnotherModel | null): HasNullables
+  @get op read(@query someParam: string | null, modelOrNull: AnotherModel | null): HasNullables
 }
 
 model AnotherModel {

--- a/packages/adl/samples/petstore/petstore.adl
+++ b/packages/adl/samples/petstore/petstore.adl
@@ -34,7 +34,7 @@ model PetId {
 
 @doc "Manage your pets."
 @resource "/pets"
-interface Pets {
+namespace Pets {
   @doc "Delete a pet."
   delete(... PetId): OkResponse<{}> | Error;
 
@@ -49,7 +49,7 @@ interface Pets {
 }
 
 @resource "/pets/{petId}/toys"
-interface ListPetToysResponse {
+namespace ListPetToysResponse {
   @list
   list(@path petId: string, @query nameFilter: string): OkResponse<ResponsePage<Toy>> | Error;
 }

--- a/packages/adl/samples/petstore/petstore.adl
+++ b/packages/adl/samples/petstore/petstore.adl
@@ -36,20 +36,20 @@ model PetId {
 @resource "/pets"
 namespace Pets {
   @doc "Delete a pet."
-  delete(... PetId): OkResponse<{}> | Error;
+  op delete(... PetId): OkResponse<{}> | Error;
 
   @fancyDoc "List pets."
   @list
-  list(@query nextLink?: string): OkResponse<ResponsePage<Pet>> | Error;
+  op list(@query nextLink?: string): OkResponse<ResponsePage<Pet>> | Error;
 
   @doc "Returns a pet. Supports eTags."
-  read(... PetId): OkResponse<Pet> | NotModified<Pet> | Error;
+  op read(... PetId): OkResponse<Pet> | NotModified<Pet> | Error;
 
-  create(@body pet: Pet): OkResponse<Pet> | Error;
+  op create(@body pet: Pet): OkResponse<Pet> | Error;
 }
 
 @resource "/pets/{petId}/toys"
 namespace ListPetToysResponse {
   @list
-  list(@path petId: string, @query nameFilter: string): OkResponse<ResponsePage<Toy>> | Error;
+  op list(@path petId: string, @query nameFilter: string): OkResponse<ResponsePage<Toy>> | Error;
 }

--- a/packages/adl/samples/rpaas/liftr.confluent/confluent.adl
+++ b/packages/adl/samples/rpaas/liftr.confluent/confluent.adl
@@ -1,7 +1,7 @@
 ﻿@ArmTrackedResource("Microsft.Confluent/organizations", OrganizationProperties)
 namespace Organization
 {
-  @post getKeys() : ArmResponse<OrganizationKeys>;
+  op @post getKeys() : ArmResponse<OrganizationKeys>;
 }
 
 """ Details of the Confluent organization. """

--- a/packages/adl/samples/rpaas/liftr.confluent/confluent.adl
+++ b/packages/adl/samples/rpaas/liftr.confluent/confluent.adl
@@ -1,5 +1,5 @@
 ﻿@ArmTrackedResource("Microsft.Confluent/organizations", OrganizationProperties)
-interface Organization
+namespace Organization
 {
   @post getKeys() : ArmResponse<OrganizationKeys>;
 }

--- a/packages/adl/samples/rpaas/liftr.confluent/confluent.rest.adl
+++ b/packages/adl/samples/rpaas/liftr.confluent/confluent.rest.adl
@@ -1,6 +1,6 @@
 ﻿
 @rest("/subscriptions/{subscription}/resourceGroups/{resourceGroup}/providers/Microsoft.Confluent/organizations/{name}")
-interface Organization 
+namespace Organization
 {
   @get get(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse<Organization>;
 
@@ -15,13 +15,13 @@ interface Organization
 }
 
 @rest("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}")
-interface OrganizationListAll
+namespace OrganizationListAll
 {
   @get listAll(@path subscription: string) : Page<OrganizationKeys>;
 }
 
 @rest("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}")
-interface OrganizationList
+namespace OrganizationList
 {
   @get listByResourceGroup(@path subscription: string, @path resourceGroup: string) : Page<OrganizationKeys>;
 }

--- a/packages/adl/samples/rpaas/liftr.confluent/confluent.rest.adl
+++ b/packages/adl/samples/rpaas/liftr.confluent/confluent.rest.adl
@@ -2,28 +2,28 @@
 @rest("/subscriptions/{subscription}/resourceGroups/{resourceGroup}/providers/Microsoft.Confluent/organizations/{name}")
 namespace Organization
 {
-  @get get(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse<Organization>;
+  @get op get(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse<Organization>;
 
   @slro("/operations", OperationStatus)
-  @put createOrUpdate(@path subscription: string, @path resourceGroup: string, @path name: string, Organization) : ArmResponse<Organization>;
-  @patch update(@path subscription: string, @path resourceGroup: string, @path name: string, OrganizationUpdate) : ArmResponse<Organization>;
+  @put op createOrUpdate(@path subscription: string, @path resourceGroup: string, @path name: string, Organization) : ArmResponse<Organization>;
+  @patch op update(@path subscription: string, @path resourceGroup: string, @path name: string, OrganizationUpdate) : ArmResponse<Organization>;
   
   @slro("/operations", OperationStatus)
-  @delete delete(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse;
+  @delete op delete(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse;
 
-  @post getKeys(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse<OrganizationKeys>;
+  @post op getKeys(@path subscription: string, @path resourceGroup: string, @path name: string) : ArmResponse<OrganizationKeys>;
 }
 
 @rest("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}")
 namespace OrganizationListAll
 {
-  @get listAll(@path subscription: string) : Page<OrganizationKeys>;
+  @get op listAll(@path subscription: string) : Page<OrganizationKeys>;
 }
 
 @rest("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}")
 namespace OrganizationList
 {
-  @get listByResourceGroup(@path subscription: string, @path resourceGroup: string) : Page<OrganizationKeys>;
+  @get op listByResourceGroup(@path subscription: string, @path resourceGroup: string) : Page<OrganizationKeys>;
 }
 
 """ Paged response """

--- a/packages/adl/test/test-parser.ts
+++ b/packages/adl/test/test-parser.ts
@@ -98,7 +98,7 @@ describe('syntax', () => {
 
   describe('tuple model expressions', () => {
     parseEach([
-      'namespace A { b(param: [number, string]): [1, "hi"] }'
+      'namespace A { op b(param: [number, string]): [1, "hi"] }'
     ]);
   });
 
@@ -139,13 +139,13 @@ describe('syntax', () => {
   describe('namespace statements', () => {
     parseEach([
       'namespace Store {}',
-      'namespace Store { read(): int32 }',
-      'namespace Store { read(): int32, write(v: int32): {} }',
-      'namespace Store { read(): int32; write(v: int32): {} }',
-      '@foo namespace Store { @dec read():number, @dec write(n: number): {} }',
-      '@foo @bar namespace Store { @foo @bar read(): number; }',
+      'namespace Store { op read(): int32 }',
+      'namespace Store { op read(): int32, op write(v: int32): {} }',
+      'namespace Store { op read(): int32; op write(v: int32): {} }',
+      '@foo namespace Store { @dec op read():number, @dec op write(n: number): {} }',
+      '@foo @bar namespace Store { @foo @bar op read(): number; }',
       'namespace Store(apiKey: string, otherArg: number) { }',
-      'namespace Store(... apiKeys, x: string) { foo(... A, b: string, ...C, d: number): void }'
+      'namespace Store(... apiKeys, x: string) { op foo(... A, b: string, ...C, d: number): void }'
     ]);
   });
 
@@ -156,7 +156,7 @@ describe('syntax', () => {
       model C = A;
       ;
       namespace I {
-        foo(): number;
+        op foo(): number;
       }
       namespace J {
 

--- a/packages/adl/test/test-parser.ts
+++ b/packages/adl/test/test-parser.ts
@@ -98,7 +98,7 @@ describe('syntax', () => {
 
   describe('tuple model expressions', () => {
     parseEach([
-      'interface A { b(param: [number, string]): [1, "hi"] }'
+      'namespace A { b(param: [number, string]): [1, "hi"] }'
     ]);
   });
 
@@ -136,16 +136,16 @@ describe('syntax', () => {
     ]);
   });
 
-  describe('interface statements', () => {
+  describe('namespace statements', () => {
     parseEach([
-      'interface Store {}',
-      'interface Store { read(): int32 }',
-      'interface Store { read(): int32, write(v: int32): {} }',
-      'interface Store { read(): int32; write(v: int32): {} }',
-      '@foo interface Store { @dec read():number, @dec write(n: number): {} }',
-      '@foo @bar interface Store { @foo @bar read(): number; }',
-      'interface Store(apiKey: string, otherArg: number) { }',
-      'interface Store(... apiKeys, x: string) { foo(... A, b: string, ...C, d: number): void }'
+      'namespace Store {}',
+      'namespace Store { read(): int32 }',
+      'namespace Store { read(): int32, write(v: int32): {} }',
+      'namespace Store { read(): int32; write(v: int32): {} }',
+      '@foo namespace Store { @dec read():number, @dec write(n: number): {} }',
+      '@foo @bar namespace Store { @foo @bar read(): number; }',
+      'namespace Store(apiKey: string, otherArg: number) { }',
+      'namespace Store(... apiKeys, x: string) { foo(... A, b: string, ...C, d: number): void }'
     ]);
   });
 
@@ -155,10 +155,10 @@ describe('syntax', () => {
       model B { }
       model C = A;
       ;
-      interface I {
+      namespace I {
         foo(): number;
       }
-      interface J {
+      namespace J {
 
       }
 


### PR DESCRIPTION
This is the first step of implementing @nguerrera's namepsace proposal (#234), basically just renaming the `interface` concept to `namespace`.  I haven't changed any of the mechanics for how this works, I think we could try that in a separate PR if you think it's safer to do it that way.