### PR TITLE
Include source file path in parse error log

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
       "protocol": "inspector",
       "request": "launch",
       "name": "run compiler",
-      "program": "${workspaceRoot}/packages/adl/dist/lib/cli.js",
+      "program": "${workspaceRoot}/packages/adl/dist/compiler/cli.js",
       "args": [
         "compile",
         "samples/scratch",

--- a/common/changes/@azure-tools/adl/parse-error-file-path_2021-02-09-22-04.json
+++ b/common/changes/@azure-tools/adl/parse-error-file-path_2021-02-09-22-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Include source file path in parse error log",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "nicholg@microsoft.com"
+}

--- a/packages/adl/compiler/parser.ts
+++ b/packages/adl/compiler/parser.ts
@@ -3,7 +3,7 @@ import { createScanner, Token } from './scanner.js';
 import * as Types from './types.js';
 
 
-export function parse(code: string) {
+export function parse(code: string | Types.SourceFile) {
   const scanner = createScanner(code, (msg, params) => error(format(msg.text, ...params)));
   nextToken();
   return parseADLScript();
@@ -589,7 +589,7 @@ export function parse(code: string) {
 
   function error(msg: string) {
     const pos = scanner.source.getLineAndCharacterOfPosition(scanner.tokenPosition);
-    throw new Error(`[${pos.line + 1}, ${pos.character + 1}] ${msg}`);
+    throw new Error(`${scanner.source.path}:${pos.line + 1}:${pos.character + 1} - error: ${msg}`);
   }
 
   function parseExpected(expectedToken: Token) {

--- a/packages/adl/compiler/program.ts
+++ b/packages/adl/compiler/program.ts
@@ -17,6 +17,7 @@ import {
   SyntaxKind,
   Type
 } from './types.js';
+import { createSourceFile } from "./scanner.js";
 
 export interface Program {
   compilerOptions: CompilerOptions;
@@ -219,7 +220,7 @@ export async function compile(rootDir: string, options?: CompilerOptions) {
   // virtual file path
   function evalAdlScript(adlScript: string, filePath?: string): void {
     filePath = filePath ?? `__virtual_file_${++virtualFileCount}`;
-    const ast = parse(adlScript);
+    const ast = parse(createSourceFile(adlScript, filePath));
     const sourceFile = {
       ast,
       path: filePath,


### PR DESCRIPTION
Tiny change that I should have included in the prior PR. Now errors from parsing and scanning will indicate the file path in addition to line and column. Still working on plumbing things so that errors after parsing indicate a location and so forth.