### PR TITLE
Add converted autorest.testserver media-types spec

### DIFF
--- a/common/changes/@azure-tools/adl/testserver-media-types_2021-02-10-00-27.json
+++ b/common/changes/@azure-tools/adl/testserver-media-types_2021-02-10-00-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Support multiple content types for request bodies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}

--- a/packages/adl/lib/decorators.ts
+++ b/packages/adl/lib/decorators.ts
@@ -41,6 +41,8 @@ export function getIntrinsicType(target: Type | undefined): string | undefined {
       target =
         (target.assignmentType?.kind === "Model" && target.assignmentType)
         || undefined;
+    } else if (target.kind === "ModelProperty") {
+      return getIntrinsicType(target.type);
     } else {
       break;
     }
@@ -75,7 +77,7 @@ export function getFormat(target: Type): string | undefined {
 const minLengthValues = new Map<Type, number>();
 
 export function minLength(program: Program, target: Type, minLength: number) {
-  if (target.kind === "Model") {
+  if (target.kind === "Model" || target.kind === "ModelProperty") {
     // Is it a model type that ultimately derives from 'string'?
     if (getIntrinsicType(target) === "string") {
       minLengthValues.set(target, minLength);
@@ -83,7 +85,7 @@ export function minLength(program: Program, target: Type, minLength: number) {
       throw new Error("Cannot apply @minLength to a non-string type");
     }
   } else {
-    throw new Error("Cannot apply @minLength to anything that isn't a Model");
+    throw new Error("Cannot apply @minLength to anything that isn't a Model or ModelProperty");
   }
 }
 
@@ -96,7 +98,7 @@ export function getMinLength(target: Type): number | undefined {
 const maxLengthValues = new Map<Type, number>();
 
 export function maxLength(program: Program, target: Type, maxLength: number) {
-  if (target.kind === "Model") {
+  if (target.kind === "Model" || target.kind === "ModelProperty") {
     // Is it a model type that ultimately derives from 'string'?
     if (getIntrinsicType(target) === "string") {
       maxLengthValues.set(target, maxLength);
@@ -104,7 +106,7 @@ export function maxLength(program: Program, target: Type, maxLength: number) {
       throw new Error("Cannot apply @maxLength to a non-string type");
     }
   } else {
-    throw new Error("Cannot apply @maxLength to anything that isn't a Model");
+    throw new Error("Cannot apply @maxLength to anything that isn't a Model or ModelProperty");
   }
 }
 

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -627,7 +627,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         modelSchema.required.push(name);
       }
 
-      modelSchema.properties[name] = getSchemaOrPlaceholder(prop.type);
+      // Apply decorators on the property to the type's schema
+      modelSchema.properties[name] = applyStringDecorators(prop, getSchemaOrPlaceholder(prop.type));
       if (description) {
         modelSchema.properties[name].description = description;
       }
@@ -734,7 +735,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     }
 
     const minLength = getMinLength(adlType);
-    if (schemaType.type === "string" && !schemaType.minLength && minLength) {
+    if (schemaType.type === "string" && !schemaType.minLength && minLength !== undefined) {
       schemaType = {
         ...schemaType,
         minLength
@@ -742,7 +743,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     }
 
     const maxLength = getMaxLength(adlType);
-    if (schemaType.type === "string" && !schemaType.maxLength && maxLength) {
+    if (schemaType.type === "string" && !schemaType.maxLength && maxLength !== undefined) {
       schemaType = {
         ...schemaType,
         maxLength

--- a/packages/adl/lib/openapi.ts
+++ b/packages/adl/lib/openapi.ts
@@ -466,6 +466,9 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     for (const [property, param] of params) {
       const key = getParameterKey(property, param);
       root.parameters[key] = {
+        // Add an extension which tells AutoRest that this is a shared operation
+        // parameter definition
+        "x-ms-parameter-location": "method",
         ...param,
       };
 

--- a/packages/adl/samples/testserver/media-types/media-types.adl
+++ b/packages/adl/samples/testserver/media-types/media-types.adl
@@ -7,6 +7,7 @@ model SourcePath {
 }
 
 model Input {
+  @doc "Input parameter."
   @body input: SourcePath;
 }
 

--- a/packages/adl/samples/testserver/media-types/media-types.adl
+++ b/packages/adl/samples/testserver/media-types/media-types.adl
@@ -1,0 +1,35 @@
+@doc "Uri or local path to source data."
+model SourcePath {
+  @minLength(0)
+  @maxLength(2048)
+  @doc "File source path."
+  source: string;
+}
+
+model Input {
+  @body input: SourcePath;
+}
+
+@resource "/mediatypes"
+namespace MediaTypes {
+  @doc "Analyze body, that could be different media types."
+  @post "analyze"
+  @operationId "AnalyzeBody"
+  op analyzeBody(
+    ... Input;
+    @header contentType:
+      "application/pdf" |
+      "application/json" |
+      "image/jpeg" |
+      "image/png" |
+      "image/tiff";
+  ): OkResponse<string>;
+
+  @doc "Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter"
+  @post "contentTypeWithEncoding"
+  @operationId "contentTypeWithEncoding"
+  op contentTypeWithEncoding(
+    ... Input;
+    @header contentType: "text/plain";
+  ): OkResponse<string>;
+}

--- a/packages/adl/scripts/regen-samples.js
+++ b/packages/adl/scripts/regen-samples.js
@@ -11,7 +11,8 @@ import { spawnSync, fork } from "child_process";
 const sampleFolders = [
   "petstore",
   "confluent",
-  "nullable"
+  "nullable",
+  "testserver/media-types"
 ];
 
 function resolvePath(...parts) {

--- a/packages/adl/test/output/petstore/openapi.json
+++ b/packages/adl/test/output/petstore/openapi.json
@@ -266,6 +266,7 @@
   },
   "parameters": {
     "PetId": {
+      "x-ms-parameter-location": "method",
       "name": "petId",
       "in": "path",
       "required": true,

--- a/packages/adl/test/output/testserver/media-types/openapi.json
+++ b/packages/adl/test/output/testserver/media-types/openapi.json
@@ -84,6 +84,7 @@
       "name": "input",
       "in": "body",
       "required": true,
+      "description": "Input parameter.",
       "schema": {
         "$ref": "#/definitions/SourcePath"
       }

--- a/packages/adl/test/output/testserver/media-types/openapi.json
+++ b/packages/adl/test/output/testserver/media-types/openapi.json
@@ -1,0 +1,90 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "(title)",
+    "version": "0000-00-00"
+  },
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/mediatypes/analyze": {
+      "post": {
+        "operationId": "AnalyzeBody",
+        "summary": "Analyze body, that could be different media types.",
+        "consumes": [
+          "application/pdf",
+          "application/json",
+          "image/jpeg",
+          "image/png",
+          "image/tiff"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Input"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/mediatypes/contentTypeWithEncoding": {
+      "post": {
+        "operationId": "contentTypeWithEncoding",
+        "summary": "Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter",
+        "consumes": [
+          "text/plain"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Input"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "SourcePath": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "File source path."
+        }
+      },
+      "description": "Uri or local path to source data.",
+      "required": [
+        "source"
+      ]
+    }
+  },
+  "parameters": {
+    "Input": {
+      "x-ms-parameter-location": "method",
+      "name": "input",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/SourcePath"
+      }
+    }
+  }
+}

--- a/packages/adl/test/output/testserver/media-types/openapi.json
+++ b/packages/adl/test/output/testserver/media-types/openapi.json
@@ -67,6 +67,8 @@
       "properties": {
         "source": {
           "type": "string",
+          "minLength": 0,
+          "maxLength": 2048,
           "description": "File source path."
         }
       },


### PR DESCRIPTION
This change is part of #262, it converts the `media-types` testserver specification to ADL.  To make it possible to implement this spec I had to add a few things to our OpenAPI emitter implementation:

- Support a `contentType` header parameter directly in the operation signature
- Allow a string union to be used for specifying multiple content types
- Add `x-ms-parameter-location: method` to shared parameter definitions [for AutoRest](https://github.com/Azure/autorest/tree/master/docs/extensions#x-ms-parameter-location)
- Enable `minLength` and `maxLength` to be applied to model properties (and not just model types)

Here's a comparison of the [original Swagger](https://github.com/Azure/autorest.testserver/blob/master/swagger/media_types.json) to the [Swagger generated by ADL](https://github.com/daviwil/adl/blob/testserver-media-types/packages/adl/test/output/testserver/media-types/openapi.json).
