### PR TITLE
Fix resolution of declared parameters in resource sub-paths

### DIFF
--- a/common/changes/@azure-tools/adl/fix-sub-path-params_2021-02-10-19-45.json
+++ b/common/changes/@azure-tools/adl/fix-sub-path-params_2021-02-10-19-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/adl",
+      "comment": "Fix resolution of declared parameters in resource sub-paths",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/adl",
+  "email": "daviwil@microsoft.com"
+}


### PR DESCRIPTION
This change fixes an issue that @jamesc found, demonstrated by this ADL snippet:

```
@resource("/v1")
namespace LibraryService {
  // TODO: This path should be "/v1/shelves/{name}:merge" but doesn't work in ADL right now
  @post("shelves/{name}:merge")
  op MergeShelves(... MergeShelvesRequest): Shelf;
}
```

The resulting Swagger has an additional `{name}` appended in the operation path because the `@post` subpath's `{name}` parameter isn't detected:

```
  "paths": {
    "/v1/shelves/{name}:merge/{name}": {
      "post": {
```

The fix is to build the full route path before attempting to detect path parameters.  The resulting Swagger looks like this:

```
  "paths": {
    "/v1/shelves/{name}:merge": {
      "post": {
```